### PR TITLE
✨feat: 상세 잡담 게시글, 전체 잡담 게시글 조회 API

### DIFF
--- a/src/main/java/com/example/backend/community/CommunityController.java
+++ b/src/main/java/com/example/backend/community/CommunityController.java
@@ -4,6 +4,7 @@ import com.example.backend.community.domain.CommunityBoard;
 import com.example.backend.community.domain.CommunityComment;
 import com.example.backend.community.dto.CommunityBoardDto;
 import com.example.backend.community.dto.CommunityCommentDto;
+import com.example.backend.community.dto.DetailCommunityBoardResponse;
 import com.example.backend.community.service.CommunityBoardService;
 import com.example.backend.community.service.CommunityCommentService;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @RestController
 @RequestMapping("/boards/community")
@@ -39,11 +41,21 @@ public class CommunityController {
                 .content(commentDto.getContent()).parentId(commentDto.getParentCommentId())
                 .createdTime(LocalDateTime.now()).communityBoard(targetBoard)
                 .build();
-        String saveResult=commentService.saveCommunityComment(comment, commentDto.getParentCommentId());
-        if(saveResult.equals("success"))
-            return new ResponseEntity<>("잡담 게시판 댓글 등록 성공",HttpStatus.CREATED);
-        else
-            return new ResponseEntity<>("존재하지 않는 댓글에 대한 대댓글 요청",HttpStatus.NOT_FOUND);
+        commentService.saveCommunityComment(comment, commentDto.getParentCommentId());
+        return new ResponseEntity<>("잡담 게시판 댓글 등록 성공",HttpStatus.CREATED);
+
+    }
+
+    @GetMapping("/{communityBoardId}")
+    public ResponseEntity<DetailCommunityBoardResponse> getDetailCommunityBoard(@PathVariable Long communityBoardId){
+        CommunityBoard targetBoard=communityBoardService.findCommunityBoardEntity(communityBoardId);
+        if(targetBoard==null){
+            return new ResponseEntity<>(null,HttpStatus.NOT_FOUND);
+        }
+        DetailCommunityBoardResponse boardResponse = communityBoardService.getDetailBoardResponse(targetBoard);
+        return new ResponseEntity<>(boardResponse,HttpStatus.OK);
+
+        //entity domain 변환 찾아보기
     }
 
 }

--- a/src/main/java/com/example/backend/community/CommunityController.java
+++ b/src/main/java/com/example/backend/community/CommunityController.java
@@ -2,12 +2,16 @@ package com.example.backend.community;
 
 import com.example.backend.community.domain.CommunityBoard;
 import com.example.backend.community.domain.CommunityComment;
+import com.example.backend.community.dto.AllCommunityBoardsResponse;
 import com.example.backend.community.dto.CommunityBoardDto;
 import com.example.backend.community.dto.CommunityCommentDto;
 import com.example.backend.community.dto.DetailCommunityBoardResponse;
 import com.example.backend.community.service.CommunityBoardService;
 import com.example.backend.community.service.CommunityCommentService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -55,8 +59,11 @@ public class CommunityController {
         communityBoardService.updateCommunityBoardViewCount(targetBoard);
         DetailCommunityBoardResponse boardResponse = communityBoardService.getDetailBoardResponse(targetBoard);
         return new ResponseEntity<>(boardResponse,HttpStatus.OK);
+    }
 
-        //entity domain 변환 찾아보기
+    @GetMapping("")
+    public ResponseEntity<List<AllCommunityBoardsResponse>> getAllCommunityBoards(@PageableDefault(size=10, sort="id", direction = Sort.Direction.DESC) Pageable pageable){
+        return new ResponseEntity<>(communityBoardService.getAllResponsesOfCommunityBoard(pageable),HttpStatus.OK);
     }
 
 }

--- a/src/main/java/com/example/backend/community/CommunityController.java
+++ b/src/main/java/com/example/backend/community/CommunityController.java
@@ -52,6 +52,7 @@ public class CommunityController {
         if(targetBoard==null){
             return new ResponseEntity<>(null,HttpStatus.NOT_FOUND);
         }
+        communityBoardService.updateCommunityBoardViewCount(targetBoard);
         DetailCommunityBoardResponse boardResponse = communityBoardService.getDetailBoardResponse(targetBoard);
         return new ResponseEntity<>(boardResponse,HttpStatus.OK);
 

--- a/src/main/java/com/example/backend/community/domain/CommunityBoard.java
+++ b/src/main/java/com/example/backend/community/domain/CommunityBoard.java
@@ -33,6 +33,7 @@ public class CommunityBoard {
 
     @Column(nullable = false)
     private Integer likeCount=0;
+    //Sort 위해 필요
 
     @Column(nullable = false)
     private Integer reportCount=0;

--- a/src/main/java/com/example/backend/community/domain/CommunityBoard.java
+++ b/src/main/java/com/example/backend/community/domain/CommunityBoard.java
@@ -51,4 +51,8 @@ public class CommunityBoard {
         this.content=content;
         this.createdTime=createdTime;
     }
+
+    public void updateViewCount(){
+        this.viewCount++;
+    }
 }

--- a/src/main/java/com/example/backend/community/domain/CommunityBoard.java
+++ b/src/main/java/com/example/backend/community/domain/CommunityBoard.java
@@ -7,6 +7,8 @@ import org.hibernate.annotations.ColumnDefault;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "communityBoards")
@@ -36,6 +38,12 @@ public class CommunityBoard {
     private Integer reportCount=0;
 
     //User column 추가 (ManyToOne)
+
+    @OneToMany(mappedBy = "communityBoard",targetEntity = CommunityComment.class)
+    private List<CommunityComment> comments=new ArrayList<>();
+
+    @OneToMany(mappedBy = "communityBoard",targetEntity = CommunityBoardImage.class)
+    private List<CommunityBoardImage> images=new ArrayList<>();
 
     @Builder
     public CommunityBoard(String title, String content, LocalDateTime createdTime){

--- a/src/main/java/com/example/backend/community/domain/CommunityBoardImage.java
+++ b/src/main/java/com/example/backend/community/domain/CommunityBoardImage.java
@@ -3,12 +3,14 @@ package com.example.backend.community.domain;
 import com.example.backend.community.domain.CommunityBoard;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
 @Entity
 @Data
 @Table(name = "communityBoardImages")
+@NoArgsConstructor
 public class CommunityBoardImage {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/backend/community/domain/CommunityComment.java
+++ b/src/main/java/com/example/backend/community/domain/CommunityComment.java
@@ -1,11 +1,15 @@
 package com.example.backend.community.domain;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Data
 @NoArgsConstructor
@@ -19,15 +23,20 @@ public class CommunityComment {
     @Column(nullable = false)
     private String content;
 
-    @Column(nullable = false)
-    private Boolean isParentComment; //true 면 원댓글 (부모댓글) 이라는 의미
-
     @Column
-    private Long commentGroupId;
-    //원댓글과 그 대댓글들의 묶음이 몇 번 그룹인지에 대한 내용
+    private Boolean isParentComment; //true 면 원댓글 (부모댓글) 이라는 의미
 
     @Column(nullable = false)
     private LocalDateTime createdTime;
+
+    @ManyToOne(targetEntity = CommunityComment.class)
+    @JoinColumn(name = "parentCommentId")
+    @JsonBackReference
+    private CommunityComment parentComment;
+
+    @OneToMany(mappedBy = "parentComment", targetEntity = CommunityComment.class)
+    @JsonManagedReference
+    private List<CommunityComment> childComments=new ArrayList<>();
 
     //하나의 게시글에 여러 댓글 -> 게시글:댓글 = 1:M
     //댓글이 M 이므로 댓글 엔티티에서 ManyToOne 사용, comment 엔티티가 연관관계의 주인
@@ -38,14 +47,11 @@ public class CommunityComment {
     //manyToOne User 연관관계 매핑 추가 필요
 
     @Builder
-    public CommunityComment(String content, Long parentId,LocalDateTime createdTime, CommunityBoard communityBoard){
+    public CommunityComment(String content, Long parentId, LocalDateTime createdTime, CommunityBoard communityBoard){
         this.content=content;
         this.isParentComment= parentId==0;
         this.createdTime=createdTime;
         this.communityBoard=communityBoard;
     }
 
-    public void setCommentGroupId(Long groupId){
-        this.commentGroupId=groupId;
-    }
 }

--- a/src/main/java/com/example/backend/community/dto/AllCommunityBoardsResponse.java
+++ b/src/main/java/com/example/backend/community/dto/AllCommunityBoardsResponse.java
@@ -1,0 +1,29 @@
+package com.example.backend.community.dto;
+
+import com.example.backend.community.domain.CommunityBoard;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+public class AllCommunityBoardsResponse {
+    private Long id;
+    private String title;
+    private String writerNickname;
+    private LocalDateTime createdTime;
+    private Integer viewCount;
+    private Integer likeCount;
+    private Integer commentCount;
+
+    public static AllCommunityBoardsResponse fromEntity(CommunityBoard board){
+        //UserNickname 파라미터, 빌더 추가
+        return AllCommunityBoardsResponse.builder()
+                .id(board.getId()).title(board.getTitle()).createdTime(board.getCreatedTime())
+                .likeCount(board.getLikeCount()).viewCount(board.getViewCount()).commentCount(board.getComments().size())
+                .build();
+    }
+}

--- a/src/main/java/com/example/backend/community/dto/CommunityCommentsResponse.java
+++ b/src/main/java/com/example/backend/community/dto/CommunityCommentsResponse.java
@@ -1,0 +1,33 @@
+package com.example.backend.community.dto;
+
+import com.example.backend.community.domain.CommunityComment;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+public class CommunityCommentsResponse {
+    private Long id;
+    private String content;
+//    private Long writerId;
+//    private String writerNickname;
+    private LocalDateTime createdTime;
+//    private Boolean isThisUserWriter; //현재 사용자가 이 댓글을 작성한 사람인가?
+//    private Boolean isThisBoardWriterCommentWriter; //이 댓글 작성자와 게시글 작성자가 동일 인물인가?
+    private List<CommunityCommentsResponse> nestedComments; //이 댓글이 부모댓글 (원댓글)인 경우, 자식 댓글들이 순서대로 들어감
+
+    public static CommunityCommentsResponse fromEntity(CommunityComment comment){
+        //User 파라미터 추가, 대댓글들은 나중에 따로 세팅
+        return CommunityCommentsResponse.builder()
+                .id(comment.getId()).content(comment.getContent()).createdTime(comment.getCreatedTime())
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/backend/community/dto/DetailCommunityBoardResponse.java
+++ b/src/main/java/com/example/backend/community/dto/DetailCommunityBoardResponse.java
@@ -1,0 +1,38 @@
+package com.example.backend.community.dto;
+
+import com.example.backend.community.domain.CommunityBoard;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+public class DetailCommunityBoardResponse {
+    private Long id;
+    private String title;
+    private String content;
+    private List<String> imageUrls; //등록된 순서대로 넘어감
+    private LocalDateTime createdTime;
+    private Integer viewCount;
+    private Integer likeCount;
+//    private Long writerId;
+//    private String writerNickname;
+//    private Boolean isThisUserWriter;
+//    private Boolean isThisBoardLikedByUser; //현재 사용자가 이 게시글에 좋아요를 눌렀는가
+    private Integer commentCount;
+    private List<CommunityCommentsResponse> comments;
+
+
+    public static DetailCommunityBoardResponse fromEntity(CommunityBoard board,List<CommunityCommentsResponse> comments,List<String> images){
+//        User 객체, 요청사용자 id 파라미터 추가 + builder 패턴에 추가
+        return DetailCommunityBoardResponse.builder()
+                .id(board.getId()).title(board.getTitle()).content(board.getContent()).commentCount(board.getComments().size())
+                .createdTime(board.getCreatedTime()).viewCount(board.getViewCount()).likeCount(board.getLikeCount())
+                .comments(comments).imageUrls(images)
+                .build();
+    }
+}

--- a/src/main/java/com/example/backend/community/repository/CommunityBoardRepository.java
+++ b/src/main/java/com/example/backend/community/repository/CommunityBoardRepository.java
@@ -1,9 +1,12 @@
 package com.example.backend.community.repository;
 
 import com.example.backend.community.domain.CommunityBoard;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CommunityBoardRepository extends JpaRepository<CommunityBoard,Long> {
+    Page<CommunityBoard> findAll(Pageable pageable);
 }

--- a/src/main/java/com/example/backend/community/service/CommunityBoardService.java
+++ b/src/main/java/com/example/backend/community/service/CommunityBoardService.java
@@ -2,6 +2,7 @@ package com.example.backend.community.service;
 
 import com.example.backend.community.domain.CommunityBoard;
 import com.example.backend.community.domain.CommunityBoardImage;
+import com.example.backend.community.domain.CommunityComment;
 import com.example.backend.community.dto.CommunityCommentsResponse;
 import com.example.backend.community.dto.DetailCommunityBoardResponse;
 import com.example.backend.community.repository.CommunityBoardImageRepository;
@@ -63,7 +64,8 @@ public class CommunityBoardService {
     }
 
     public DetailCommunityBoardResponse getDetailBoardResponse(CommunityBoard communityBoard){
-        //comment 가져올 때 부모 댓글들만 가져오게 수정해주어야함
+        List<CommunityComment> originComments=communityBoard.getComments();
+        originComments.removeIf(comment -> !comment.getIsParentComment()); //Iterator 을 사용한 remove statement 를 Collections.removeIf로 단순화
         List<CommunityCommentsResponse> comments=commentService.getCommentsResponses(communityBoard.getComments());
         List<String> images=this.getImageUrlsInPost(communityBoard);
         return DetailCommunityBoardResponse.fromEntity(communityBoard,comments,images);

--- a/src/main/java/com/example/backend/community/service/CommunityBoardService.java
+++ b/src/main/java/com/example/backend/community/service/CommunityBoardService.java
@@ -2,6 +2,8 @@ package com.example.backend.community.service;
 
 import com.example.backend.community.domain.CommunityBoard;
 import com.example.backend.community.domain.CommunityBoardImage;
+import com.example.backend.community.dto.CommunityCommentsResponse;
+import com.example.backend.community.dto.DetailCommunityBoardResponse;
 import com.example.backend.community.repository.CommunityBoardImageRepository;
 import com.example.backend.community.repository.CommunityBoardRepository;
 import com.example.backend.s3Image.AwsS3Service;
@@ -21,6 +23,7 @@ public class CommunityBoardService {
     private final CommunityBoardRepository communityBoardRepository;
     private final AwsS3Service awsS3Service;
     private final CommunityBoardImageRepository communityImageRepository;
+    private final CommunityCommentService commentService;
 
     public void savePost(CommunityBoard communityBoard, List<MultipartFile> files){
         communityBoardRepository.save(communityBoard);
@@ -42,9 +45,28 @@ public class CommunityBoardService {
         }
     }
 
+    public List<String> getImageUrlsInPost(CommunityBoard communityBoard){
+        List<CommunityBoardImage> images = communityBoard.getImages();
+        List<String> imageUrls=new ArrayList<>();
+        if(images==null){
+            return imageUrls;
+        }
+        for(CommunityBoardImage image:images){
+            imageUrls.add(image.getImageUrl());
+        }
+        return imageUrls;
+    }
+
     public CommunityBoard findCommunityBoardEntity(Long boardId){
         Optional<CommunityBoard> board = communityBoardRepository.findById(boardId);
         return board.orElse(null);
+    }
+
+    public DetailCommunityBoardResponse getDetailBoardResponse(CommunityBoard communityBoard){
+        //comment 가져올 때 부모 댓글들만 가져오게 수정해주어야함
+        List<CommunityCommentsResponse> comments=commentService.getCommentsResponses(communityBoard.getComments());
+        List<String> images=this.getImageUrlsInPost(communityBoard);
+        return DetailCommunityBoardResponse.fromEntity(communityBoard,comments,images);
     }
 
 }

--- a/src/main/java/com/example/backend/community/service/CommunityBoardService.java
+++ b/src/main/java/com/example/backend/community/service/CommunityBoardService.java
@@ -3,12 +3,15 @@ package com.example.backend.community.service;
 import com.example.backend.community.domain.CommunityBoard;
 import com.example.backend.community.domain.CommunityBoardImage;
 import com.example.backend.community.domain.CommunityComment;
+import com.example.backend.community.dto.AllCommunityBoardsResponse;
 import com.example.backend.community.dto.CommunityCommentsResponse;
 import com.example.backend.community.dto.DetailCommunityBoardResponse;
 import com.example.backend.community.repository.CommunityBoardImageRepository;
 import com.example.backend.community.repository.CommunityBoardRepository;
 import com.example.backend.s3Image.AwsS3Service;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -74,6 +77,17 @@ public class CommunityBoardService {
     public void updateCommunityBoardViewCount(CommunityBoard board){
         board.updateViewCount();
         communityBoardRepository.save(board);
+    }
+
+    public List<AllCommunityBoardsResponse> getAllResponsesOfCommunityBoard(Pageable pageable){
+        Page<CommunityBoard> boardPages = communityBoardRepository.findAll(pageable);
+        //좋아요 순, 조회 순 정렬 시 "값이 동일한 애들 중에서는 더 최근 게시글이 먼저 나오게 수정: -> Sort 차순위 설정,,,?
+        //그러려면 sort 객체를 따로 만들어주어야 하나?
+        List<AllCommunityBoardsResponse> responses=new ArrayList<>();
+        for(CommunityBoard board : boardPages){
+            responses.add(AllCommunityBoardsResponse.fromEntity(board));
+        }
+        return responses;
     }
 
 }

--- a/src/main/java/com/example/backend/community/service/CommunityBoardService.java
+++ b/src/main/java/com/example/backend/community/service/CommunityBoardService.java
@@ -71,4 +71,9 @@ public class CommunityBoardService {
         return DetailCommunityBoardResponse.fromEntity(communityBoard,comments,images);
     }
 
+    public void updateCommunityBoardViewCount(CommunityBoard board){
+        board.updateViewCount();
+        communityBoardRepository.save(board);
+    }
+
 }

--- a/src/main/java/com/example/backend/community/service/CommunityCommentService.java
+++ b/src/main/java/com/example/backend/community/service/CommunityCommentService.java
@@ -1,11 +1,16 @@
 package com.example.backend.community.service;
 
+import com.example.backend.community.domain.CommunityBoard;
 import com.example.backend.community.domain.CommunityComment;
+import com.example.backend.community.dto.CommunityCommentsResponse;
 import com.example.backend.community.repository.CommunityCommentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -14,27 +19,44 @@ import java.util.Optional;
 public class CommunityCommentService {
     private final CommunityCommentRepository commentRepository;
 
-    public String saveCommunityComment(CommunityComment comment,Long parentId){
-        CommunityComment savedComment = commentRepository.save(comment);
-        if(parentId!=0&& !checkParentComment(parentId)){
-            return "fail";
-        }
-        setCommentGroupId(savedComment, parentId);
-        return "success";
-    }
-
-    private void setCommentGroupId(CommunityComment comment, Long parentId){
-        if(parentId==0){
-            comment.setCommentGroupId(comment.getId());
-        }else{
-            comment.setCommentGroupId(parentId);
+    public void saveCommunityComment(CommunityComment comment,Long parentId){
+        CommunityComment parentComment = checkParentComment(parentId);
+        if(parentComment!=null){
+            comment.setParentComment(parentComment);
         }
         commentRepository.save(comment);
     }
 
-    private Boolean checkParentComment(Long parentId){
-        Optional<CommunityComment> parentComment = commentRepository.findById(parentId);
-        return parentComment.isPresent();
 
+    private CommunityComment checkParentComment(Long parentId){
+        if(parentId.equals(0L))
+            return null;
+        Optional<CommunityComment> parentComment = commentRepository.findById(parentId);
+        return parentComment.orElse(null);
+
+    }
+
+    public List<CommunityCommentsResponse> getCommentsResponses(List<CommunityComment> comments){
+        List<CommunityCommentsResponse> responses=new ArrayList<>();
+        for(CommunityComment comment:comments){
+            responses.add(toCommentResponse(comment));
+        }
+        return responses;
+    }
+
+
+    private CommunityCommentsResponse toCommentResponse(CommunityComment comment){
+        CommunityCommentsResponse response = CommunityCommentsResponse.fromEntity(comment);
+        if(comment.getIsParentComment()){
+            List<CommunityComment> childComments = comment.getChildComments();
+            List<CommunityCommentsResponse> childResponses=new ArrayList<>();
+            for(CommunityComment child:childComments){
+                childResponses.add(toCommentResponse(child));
+            }
+            response.setNestedComments(childResponses);
+        }else{
+            response.setNestedComments(null);
+        }
+        return response;
     }
 }


### PR DESCRIPTION
제목
---
잡담 게시판 - 상세 게시글 조회 API 구현
잡담 게시판 - 전체글 조회 + 페이징 API 구현

상세 구현내용
---
게시글 조회용 DTO 생성
상세 게시글 조회 시 댓글과 각 댓글에 대한 대댓글 조회 기능 구현
전체 게시글 조회용 DTO 생성
전체 겟글 조회 시 쿼리 스트링 통해 페이징, 정렬 가능

작업내용
---
- [x] 기능 추가
- [x] 기능 수정
- [ ] 버그 수정
- [ ] 기타 설정

주의사항
---

- CommunityComment Entity - 대댓글 관련 구성 변경:  부모 댓글의 pk를 fk로 가지도록 수정 => commentGroupId 컬럼 삭제, parentCommentId (FK) 추가
- **한 엔티티 내에서 양방향 연관관계 매핑으로 바로 대댓글들 가져올 수 있게 수정**
- Entity / DTO 변환 과정: 일단 builder로 작성 -> 추후 Custom MapStruct로 변경할 예정
- User 연관관계 매핑 추가 예정
