### PR TITLE
✨ feat: 잡담게시판 좋아요 API 및 유저 더미데이터 연결

### DIFF
--- a/src/main/java/com/example/backend/community/CommunityController.java
+++ b/src/main/java/com/example/backend/community/CommunityController.java
@@ -2,10 +2,7 @@ package com.example.backend.community;
 
 import com.example.backend.community.domain.CommunityBoard;
 import com.example.backend.community.domain.CommunityComment;
-import com.example.backend.community.dto.AllCommunityBoardsResponse;
-import com.example.backend.community.dto.CommunityBoardDto;
-import com.example.backend.community.dto.CommunityCommentDto;
-import com.example.backend.community.dto.DetailCommunityBoardResponse;
+import com.example.backend.community.dto.*;
 import com.example.backend.community.service.CommunityBoardService;
 import com.example.backend.community.service.CommunityCommentService;
 import com.example.backend.like.LikeService;
@@ -70,8 +67,10 @@ public class CommunityController {
     }
 
     @GetMapping("")
-    public ResponseEntity<List<AllCommunityBoardsResponse>> getAllCommunityBoards(@PageableDefault(size=10, sort="id", direction = Sort.Direction.DESC) Pageable pageable){
-        return new ResponseEntity<>(communityBoardService.getAllResponsesOfCommunityBoard(pageable),HttpStatus.OK);
+    public ResponseEntity<AllBoardResponseWithPageCount> getAllCommunityBoards(@PageableDefault(size=10, sort="id", direction = Sort.Direction.DESC) Pageable pageable){
+        int totalPageCount = communityBoardService.getTotalPageCount();
+        List<AllCommunityBoardsResponse> allResponsesOfCommunityBoard = communityBoardService.getAllResponsesOfCommunityBoard(pageable);
+        return new ResponseEntity<>(new AllBoardResponseWithPageCount(totalPageCount,allResponsesOfCommunityBoard),HttpStatus.OK);
     }
 
     @PostMapping("/{communityBoardId}/likes")

--- a/src/main/java/com/example/backend/community/CommunityController.java
+++ b/src/main/java/com/example/backend/community/CommunityController.java
@@ -8,6 +8,9 @@ import com.example.backend.community.dto.CommunityCommentDto;
 import com.example.backend.community.dto.DetailCommunityBoardResponse;
 import com.example.backend.community.service.CommunityBoardService;
 import com.example.backend.community.service.CommunityCommentService;
+import com.example.backend.like.LikeService;
+import com.example.backend.user.UserService;
+import com.example.backend.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -25,6 +28,8 @@ import java.util.List;
 public class CommunityController {
     private final CommunityBoardService communityBoardService;
     private final CommunityCommentService commentService;
+    private final LikeService likeService;
+    private final UserService userService;
 
     @PostMapping("")
     public ResponseEntity<String> createCommunityPost(CommunityBoardDto communityBoardDto){
@@ -54,18 +59,28 @@ public class CommunityController {
 
     @GetMapping("/{communityBoardId}")
     public ResponseEntity<DetailCommunityBoardResponse> getDetailCommunityBoard(@PathVariable Long communityBoardId){
+        Long loginId=1L;
         CommunityBoard targetBoard=communityBoardService.findCommunityBoardEntity(communityBoardId);
         if(targetBoard==null){
             return new ResponseEntity<>(null,HttpStatus.NOT_FOUND);
         }
         communityBoardService.updateCommunityBoardViewCount(targetBoard);
-        DetailCommunityBoardResponse boardResponse = communityBoardService.getDetailBoardResponse(targetBoard);
+        DetailCommunityBoardResponse boardResponse = communityBoardService.getDetailBoardResponse(targetBoard,loginId);
         return new ResponseEntity<>(boardResponse,HttpStatus.OK);
     }
 
     @GetMapping("")
     public ResponseEntity<List<AllCommunityBoardsResponse>> getAllCommunityBoards(@PageableDefault(size=10, sort="id", direction = Sort.Direction.DESC) Pageable pageable){
         return new ResponseEntity<>(communityBoardService.getAllResponsesOfCommunityBoard(pageable),HttpStatus.OK);
+    }
+
+    @PostMapping("/{communityBoardId}/likes")
+    public ResponseEntity<Integer> setLikeOnCommunityBoard(@PathVariable Long communityBoardId){
+        Long loginId=1L;
+        CommunityBoard communityBoard = communityBoardService.findCommunityBoardEntity(communityBoardId);
+        User user = userService.findUserById(loginId);
+        int likeCount = likeService.saveLike(communityBoard, user);
+        return new ResponseEntity<>(likeCount,HttpStatus.OK);
     }
 
 }

--- a/src/main/java/com/example/backend/community/CommunityController.java
+++ b/src/main/java/com/example/backend/community/CommunityController.java
@@ -28,6 +28,7 @@ public class CommunityController {
 
     @PostMapping("")
     public ResponseEntity<String> createCommunityPost(CommunityBoardDto communityBoardDto){
+        //principal 로 유저 정보 받아오는 부분 추가 (회원가입, 로그인 구현 후)
         CommunityBoard post= CommunityBoard.builder()
                 .title(communityBoardDto.getTitle()).content(communityBoardDto.getContent()).createdTime(LocalDateTime.now())
                 .build();
@@ -37,6 +38,7 @@ public class CommunityController {
 
     @PostMapping("/{communityBoardId}/comments")
     public ResponseEntity<String> createCommunityComment(@PathVariable Long communityBoardId, @RequestBody CommunityCommentDto commentDto){
+        //principal 추가
         CommunityBoard targetBoard=communityBoardService.findCommunityBoardEntity(communityBoardId);
         if(targetBoard==null){
             return new ResponseEntity<>("존재하지 않는 게시글에 대한 댓글 등록 요청",HttpStatus.NOT_FOUND);

--- a/src/main/java/com/example/backend/community/domain/CommunityBoard.java
+++ b/src/main/java/com/example/backend/community/domain/CommunityBoard.java
@@ -1,5 +1,6 @@
 package com.example.backend.community.domain;
 
+import com.example.backend.user.domain.User;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -38,7 +39,10 @@ public class CommunityBoard {
     @Column(nullable = false)
     private Integer reportCount=0;
 
-    //User column 추가 (ManyToOne)
+    //추후 필요시 양방향 매핑 추가
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "userId")
+    private User user;
 
     @OneToMany(mappedBy = "communityBoard",targetEntity = CommunityComment.class)
     private List<CommunityComment> comments=new ArrayList<>();

--- a/src/main/java/com/example/backend/community/domain/CommunityComment.java
+++ b/src/main/java/com/example/backend/community/domain/CommunityComment.java
@@ -1,5 +1,6 @@
 package com.example.backend.community.domain;
 
+import com.example.backend.user.domain.User;
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import lombok.Builder;
@@ -43,7 +44,9 @@ public class CommunityComment {
     @JoinColumn(name = "communityBoardId")
     private CommunityBoard communityBoard;
 
-    //manyToOne User 연관관계 매핑 추가 필요
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "userId")
+    private User user;
 
     @Builder
     public CommunityComment(String content, Long parentId, LocalDateTime createdTime, CommunityBoard communityBoard){

--- a/src/main/java/com/example/backend/community/dto/AllBoardResponseWithPageCount.java
+++ b/src/main/java/com/example/backend/community/dto/AllBoardResponseWithPageCount.java
@@ -1,0 +1,18 @@
+package com.example.backend.community.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class AllBoardResponseWithPageCount {
+    Integer totalPageCount;
+    List<AllCommunityBoardsResponse> boardsResponses;
+
+    public AllBoardResponseWithPageCount(int count, List<AllCommunityBoardsResponse> boards){
+        this.totalPageCount=count;
+        this.boardsResponses=boards;
+    }
+}

--- a/src/main/java/com/example/backend/community/dto/AllCommunityBoardsResponse.java
+++ b/src/main/java/com/example/backend/community/dto/AllCommunityBoardsResponse.java
@@ -24,6 +24,7 @@ public class AllCommunityBoardsResponse {
         return AllCommunityBoardsResponse.builder()
                 .id(board.getId()).title(board.getTitle()).createdTime(board.getCreatedTime())
                 .likeCount(board.getLikeCount()).viewCount(board.getViewCount()).commentCount(board.getComments().size())
+                .writerNickname(board.getUser().getNickname())
                 .build();
     }
 }

--- a/src/main/java/com/example/backend/community/dto/CommunityCommentsResponse.java
+++ b/src/main/java/com/example/backend/community/dto/CommunityCommentsResponse.java
@@ -1,6 +1,7 @@
 package com.example.backend.community.dto;
 
 import com.example.backend.community.domain.CommunityComment;
+import com.example.backend.user.domain.User;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,6 +10,7 @@ import lombok.Setter;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 @Getter
 @Setter
@@ -16,17 +18,20 @@ import java.util.List;
 public class CommunityCommentsResponse {
     private Long id;
     private String content;
-//    private Long writerId;
-//    private String writerNickname;
+    private Long writerId;
+    private String writerNickname;
     private LocalDateTime createdTime;
-//    private Boolean isThisUserWriter; //현재 사용자가 이 댓글을 작성한 사람인가?
-//    private Boolean isThisBoardWriterCommentWriter; //이 댓글 작성자와 게시글 작성자가 동일 인물인가?
+    private Boolean isThisUserWriter; //현재 사용자가 이 댓글을 작성한 사람인가?
+    private Boolean isThisBoardWriterCommentWriter; //이 댓글 작성자와 게시글 작성자가 동일 인물인가?
     private List<CommunityCommentsResponse> nestedComments; //이 댓글이 부모댓글 (원댓글)인 경우, 자식 댓글들이 순서대로 들어감
 
-    public static CommunityCommentsResponse fromEntity(CommunityComment comment){
+    public static CommunityCommentsResponse fromEntity(CommunityComment comment, Long boardWriterId, Long loginId){
+        User user = comment.getUser();
         //User 파라미터 추가, 대댓글들은 나중에 따로 세팅
         return CommunityCommentsResponse.builder()
                 .id(comment.getId()).content(comment.getContent()).createdTime(comment.getCreatedTime())
+                .writerId(user.getUserId()).writerNickname(user.getNickname())
+                .isThisUserWriter(user.getUserId().equals(loginId)).isThisBoardWriterCommentWriter(user.getUserId().equals(boardWriterId))
                 .build();
     }
 

--- a/src/main/java/com/example/backend/community/dto/DetailCommunityBoardResponse.java
+++ b/src/main/java/com/example/backend/community/dto/DetailCommunityBoardResponse.java
@@ -1,6 +1,7 @@
 package com.example.backend.community.dto;
 
 import com.example.backend.community.domain.CommunityBoard;
+import com.example.backend.user.domain.User;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -19,20 +20,22 @@ public class DetailCommunityBoardResponse {
     private LocalDateTime createdTime;
     private Integer viewCount;
     private Integer likeCount;
-//    private Long writerId;
-//    private String writerNickname;
-//    private Boolean isThisUserWriter;
+    private Long writerId;
+    private String writerNickname;
+    private Boolean isThisUserWriter;
 //    private Boolean isThisBoardLikedByUser; //현재 사용자가 이 게시글에 좋아요를 눌렀는가
     private Integer commentCount;
     private List<CommunityCommentsResponse> comments;
 
 
-    public static DetailCommunityBoardResponse fromEntity(CommunityBoard board,List<CommunityCommentsResponse> comments,List<String> images){
+    public static DetailCommunityBoardResponse fromEntity(CommunityBoard board,List<CommunityCommentsResponse> comments,List<String> images,Long loginId){
 //        User 객체, 요청사용자 id 파라미터 추가 + builder 패턴에 추가
+        User boardWriter=board.getUser();
         return DetailCommunityBoardResponse.builder()
                 .id(board.getId()).title(board.getTitle()).content(board.getContent()).commentCount(board.getComments().size())
                 .createdTime(board.getCreatedTime()).viewCount(board.getViewCount()).likeCount(board.getLikeCount())
                 .comments(comments).imageUrls(images)
+                .writerId(boardWriter.getUserId()).writerNickname(boardWriter.getNickname()).isThisUserWriter(boardWriter.getUserId().equals(loginId))
                 .build();
     }
 }

--- a/src/main/java/com/example/backend/community/service/CommunityBoardService.java
+++ b/src/main/java/com/example/backend/community/service/CommunityBoardService.java
@@ -71,7 +71,7 @@ public class CommunityBoardService {
         originComments.removeIf(comment -> !comment.getIsParentComment()); //Iterator 을 사용한 remove statement 를 Collections.removeIf로 단순화
         List<CommunityCommentsResponse> comments=commentService.getCommentsResponses(originComments);
         List<String> images=this.getImageUrlsInPost(communityBoard);
-        return DetailCommunityBoardResponse.fromEntity(communityBoard,comments,images);
+        return DetailCommunityBoardResponse.fromEntity(communityBoard,comments,images,1L);
     }
 
     public void updateCommunityBoardViewCount(CommunityBoard board){

--- a/src/main/java/com/example/backend/community/service/CommunityBoardService.java
+++ b/src/main/java/com/example/backend/community/service/CommunityBoardService.java
@@ -66,6 +66,11 @@ public class CommunityBoardService {
         return board.orElse(null);
     }
 
+    public int getTotalPageCount(){
+        List<CommunityBoard> communityBoards = communityBoardRepository.findAll();
+        return communityBoards.size()/10+1;
+    }
+
     public DetailCommunityBoardResponse getDetailBoardResponse(CommunityBoard communityBoard,Long loginId){
         List<CommunityComment> originComments=communityBoard.getComments();
         originComments.removeIf(comment -> !comment.getIsParentComment()); //Iterator 을 사용한 remove statement 를 Collections.removeIf로 단순화

--- a/src/main/java/com/example/backend/community/service/CommunityBoardService.java
+++ b/src/main/java/com/example/backend/community/service/CommunityBoardService.java
@@ -19,6 +19,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional
@@ -55,9 +56,10 @@ public class CommunityBoardService {
         if(images==null){
             return imageUrls;
         }
-        for(CommunityBoardImage image:images){
-            imageUrls.add(image.getImageUrl());
-        }
+        imageUrls = images.stream()
+                .map(CommunityBoardImage::getImageUrl)
+                .collect(Collectors.toList());
+
         return imageUrls;
     }
 
@@ -86,11 +88,9 @@ public class CommunityBoardService {
 
     public List<AllCommunityBoardsResponse> getAllResponsesOfCommunityBoard(Pageable pageable){
         Page<CommunityBoard> boardPages = communityBoardRepository.findAll(pageable);
-        List<AllCommunityBoardsResponse> responses=new ArrayList<>();
-        for(CommunityBoard board : boardPages){
-            responses.add(AllCommunityBoardsResponse.fromEntity(board));
-        }
-        return responses;
+        return boardPages.stream()
+                .map(AllCommunityBoardsResponse::fromEntity) //lambda (board -> AllCommunityBoardsResponse.fromEntity(board)) 를 변경한 것
+                .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/com/example/backend/community/service/CommunityBoardService.java
+++ b/src/main/java/com/example/backend/community/service/CommunityBoardService.java
@@ -66,12 +66,12 @@ public class CommunityBoardService {
         return board.orElse(null);
     }
 
-    public DetailCommunityBoardResponse getDetailBoardResponse(CommunityBoard communityBoard){
+    public DetailCommunityBoardResponse getDetailBoardResponse(CommunityBoard communityBoard,Long loginId){
         List<CommunityComment> originComments=communityBoard.getComments();
         originComments.removeIf(comment -> !comment.getIsParentComment()); //Iterator 을 사용한 remove statement 를 Collections.removeIf로 단순화
-        List<CommunityCommentsResponse> comments=commentService.getCommentsResponses(originComments);
+        List<CommunityCommentsResponse> comments=commentService.getCommentsResponses(originComments,loginId);
         List<String> images=this.getImageUrlsInPost(communityBoard);
-        return DetailCommunityBoardResponse.fromEntity(communityBoard,comments,images,1L);
+        return DetailCommunityBoardResponse.fromEntity(communityBoard,comments,images,loginId);
     }
 
     public void updateCommunityBoardViewCount(CommunityBoard board){

--- a/src/main/java/com/example/backend/community/service/CommunityCommentService.java
+++ b/src/main/java/com/example/backend/community/service/CommunityCommentService.java
@@ -37,7 +37,7 @@ public class CommunityCommentService {
 
     }
 
-    public List<CommunityCommentsResponse> getCommentsResponses(List<CommunityComment> comments){
+    public List<CommunityCommentsResponse> getCommentsResponses(List<CommunityComment> comments,Long loginId){
         Long boardWriterId=0L;
         if(comments!=null&&!comments.isEmpty()){
             CommunityComment comment = comments.get(0);
@@ -46,20 +46,20 @@ public class CommunityCommentService {
         List<CommunityCommentsResponse> responses=new ArrayList<>();
 
         for(CommunityComment comment:comments){
-            responses.add(toCommentResponse(comment,boardWriterId));
+            responses.add(toCommentResponse(comment,boardWriterId,loginId));
         }
         return responses;
     }
 
 
-    private CommunityCommentsResponse toCommentResponse(CommunityComment comment,Long boardWriterId){
+    private CommunityCommentsResponse toCommentResponse(CommunityComment comment,Long boardWriterId,Long loginId){
 
-        CommunityCommentsResponse response = CommunityCommentsResponse.fromEntity(comment,boardWriterId,1L);
+        CommunityCommentsResponse response = CommunityCommentsResponse.fromEntity(comment,boardWriterId,loginId);
         if(comment.getIsParentComment()){
             List<CommunityComment> childComments = comment.getChildComments();
             List<CommunityCommentsResponse> childResponses=new ArrayList<>();
             for(CommunityComment child:childComments){
-                childResponses.add(toCommentResponse(child,boardWriterId));
+                childResponses.add(toCommentResponse(child,boardWriterId,loginId));
             }
             response.setNestedComments(childResponses);
         }else{

--- a/src/main/java/com/example/backend/community/service/CommunityCommentService.java
+++ b/src/main/java/com/example/backend/community/service/CommunityCommentService.java
@@ -4,6 +4,7 @@ import com.example.backend.community.domain.CommunityBoard;
 import com.example.backend.community.domain.CommunityComment;
 import com.example.backend.community.dto.CommunityCommentsResponse;
 import com.example.backend.community.repository.CommunityCommentRepository;
+import com.example.backend.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,21 +38,28 @@ public class CommunityCommentService {
     }
 
     public List<CommunityCommentsResponse> getCommentsResponses(List<CommunityComment> comments){
+        Long boardWriterId=0L;
+        if(comments!=null&&!comments.isEmpty()){
+            CommunityComment comment = comments.get(0);
+            boardWriterId = comment.getCommunityBoard().getUser().getUserId();
+        }
         List<CommunityCommentsResponse> responses=new ArrayList<>();
+
         for(CommunityComment comment:comments){
-            responses.add(toCommentResponse(comment));
+            responses.add(toCommentResponse(comment,boardWriterId));
         }
         return responses;
     }
 
 
-    private CommunityCommentsResponse toCommentResponse(CommunityComment comment){
-        CommunityCommentsResponse response = CommunityCommentsResponse.fromEntity(comment);
+    private CommunityCommentsResponse toCommentResponse(CommunityComment comment,Long boardWriterId){
+
+        CommunityCommentsResponse response = CommunityCommentsResponse.fromEntity(comment,boardWriterId,1L);
         if(comment.getIsParentComment()){
             List<CommunityComment> childComments = comment.getChildComments();
             List<CommunityCommentsResponse> childResponses=new ArrayList<>();
             for(CommunityComment child:childComments){
-                childResponses.add(toCommentResponse(child));
+                childResponses.add(toCommentResponse(child,boardWriterId));
             }
             response.setNestedComments(childResponses);
         }else{

--- a/src/main/java/com/example/backend/like/Like.java
+++ b/src/main/java/com/example/backend/like/Like.java
@@ -1,0 +1,40 @@
+package com.example.backend.like;
+
+import com.example.backend.community.domain.CommunityBoard;
+import com.example.backend.user.domain.User;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "likes")
+@Data
+@NoArgsConstructor
+public class Like {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "likeId")
+    private Long id;
+
+    @Column(nullable = false)
+    private Boolean likeStatus = true;
+
+    @ManyToOne
+    @JoinColumn(name = "userId")
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "communityBoardId")
+    private CommunityBoard communityBoard;
+
+    @Builder
+    public Like(User user, CommunityBoard communityBoard){
+        this.user=user;
+        this.communityBoard=communityBoard;
+    }
+
+    public void modifyLikeStatus(){
+        this.likeStatus=!this.likeStatus;
+    }
+}

--- a/src/main/java/com/example/backend/like/LikeRepository.java
+++ b/src/main/java/com/example/backend/like/LikeRepository.java
@@ -1,0 +1,14 @@
+package com.example.backend.like;
+
+import com.example.backend.community.domain.CommunityBoard;
+import com.example.backend.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface LikeRepository extends JpaRepository<Like,Long> {
+    Like findByUserAndCommunityBoard(User user, CommunityBoard communityBoard);
+    List<Like> findAllByCommunityBoard(CommunityBoard communityBoard);
+}

--- a/src/main/java/com/example/backend/like/LikeService.java
+++ b/src/main/java/com/example/backend/like/LikeService.java
@@ -1,0 +1,41 @@
+package com.example.backend.like;
+
+import com.example.backend.community.domain.CommunityBoard;
+import com.example.backend.community.domain.CommunityComment;
+import com.example.backend.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class LikeService {
+    private final LikeRepository likeRepository;
+
+    public int saveLike(CommunityBoard communityBoard, User user){
+        //존재하는지 찾아서, 없으면 새롭게 하나 추가해주고 있으면 status 를 반대로 바꿔주기
+        Like like=findExistingLike(communityBoard,user);
+        if(like==null){
+            like=Like.builder().communityBoard(communityBoard).user(user).build();
+        }
+        else{
+            like.modifyLikeStatus();
+        }
+        likeRepository.save(like);
+        return getLikeCount(communityBoard);
+    }
+
+    public Like findExistingLike(CommunityBoard communityBoard, User user){
+        return likeRepository.findByUserAndCommunityBoard(user, communityBoard);
+    }
+
+    public int getLikeCount(CommunityBoard communityBoard){
+        List<Like> likeList = likeRepository.findAllByCommunityBoard(communityBoard);
+        return likeList.size();
+    }
+
+
+}

--- a/src/main/java/com/example/backend/like/LikeService.java
+++ b/src/main/java/com/example/backend/like/LikeService.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional
@@ -32,9 +33,13 @@ public class LikeService {
         return likeRepository.findByUserAndCommunityBoard(user, communityBoard);
     }
 
+    //고민 중: OneToMany 로 양방향 매핑을 해서 CommunityBoard 에서 List 로 가져올지, 아니면 지금 처럼 findBy 로 like 객체에서 찾아올지
     public int getLikeCount(CommunityBoard communityBoard){
-        List<Like> likeList = likeRepository.findAllByCommunityBoard(communityBoard);
-        return likeList.size();
+        List<Like> originLikes = likeRepository.findAllByCommunityBoard(communityBoard);
+        List<Like> likes = originLikes.stream()
+                .filter(like -> like.getLikeStatus().equals(true))
+                .collect(Collectors.toList());
+        return likes.size();
     }
 
 

--- a/src/main/java/com/example/backend/user/UserRepository.java
+++ b/src/main/java/com/example/backend/user/UserRepository.java
@@ -1,0 +1,9 @@
+package com.example.backend.user;
+
+import com.example.backend.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/com/example/backend/user/UserService.java
+++ b/src/main/java/com/example/backend/user/UserService.java
@@ -1,0 +1,20 @@
+package com.example.backend.user;
+
+import com.example.backend.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+
+    public User findUserById(Long userId){
+        Optional<User> user = userRepository.findById(userId);
+        return user.orElse(null);
+    }
+}


### PR DESCRIPTION
제목
---
잡담게시판 좋아요 등록/취소 API 구현
잡담게시판 조회 시 유저 더미데이터 연결
전체 잡담게시판 조회 시 전체 페이지 수 함께 반환

상세 구현내용
---
1. 좋아요 등록, 취소 시 반영 및 해당 게시글에 대한 총 좋아요 개수 return
2. 상세 잡담게시판, 전체 잡담게시판 조회 시 사용자 정보 추가 (더미데이터)
3. 전체 잡담게시글 조회 시 totalPageCount 추가
4. 좋아요 구현 위한 Likes 테이블 추가
5. user_id 기반 사용자 엔티티 조회 메소드 구현

작업사항
---
- [x] 기능 추가
- [x] 기능 수정
- [ ] 버그 수정
- [ ] 기타 설정

주의사항
---
1. 로그인 기능 아직 구현 안돼서 loginId=1로 고정해두고 현재 로그인된 사용자의 글 작성 여부, 좋아요 여부 표시 
2. 원래 테이블명 단수형으로 가야하지만 'like'는 MySQL의 예약어라서 'likes' 테이블로 생성
3. 잡담 게시글, 댓글 등록 시에 로그인된 사용자 정보로 User 객체 추가해주는 부분 구현 안됨 