### PR TITLE
🔨 mod: 잡담게시판 API 수정

### DIFF
--- a/src/main/java/com/example/backend/community/CommunityController.java
+++ b/src/main/java/com/example/backend/community/CommunityController.java
@@ -70,10 +70,9 @@ public class CommunityController {
     }
 
     @GetMapping("")
-    public ResponseEntity<AllBoardResponseWithPageCount> getAllCommunityBoards(@PageableDefault(size=10, sort="id", direction = Sort.Direction.DESC) Pageable pageable){
-        int totalPageCount = communityBoardService.getTotalPageCount();
-        List<AllCommunityBoardsResponse> allResponsesOfCommunityBoard = communityBoardService.getAllResponsesOfCommunityBoard(pageable);
-        return new ResponseEntity<>(new AllBoardResponseWithPageCount(totalPageCount,allResponsesOfCommunityBoard),HttpStatus.OK);
+    public ResponseEntity<AllBoardResponseWithPageCount> getAllCommunityBoards(@PageableDefault(size=3, sort="id", direction = Sort.Direction.DESC) Pageable pageable,
+                                                                               @RequestParam(required = false) String q){
+        return new ResponseEntity<>(communityBoardService.getAllResponsesOfCommunityBoard(pageable,q),HttpStatus.OK);
     }
 
     @GetMapping("best")

--- a/src/main/java/com/example/backend/community/CommunityController.java
+++ b/src/main/java/com/example/backend/community/CommunityController.java
@@ -34,8 +34,10 @@ public class CommunityController {
     @PostMapping("")
     public ResponseEntity<String> createCommunityPost(CommunityBoardDto communityBoardDto){
         //principal 로 유저 정보 받아오는 부분 추가 (회원가입, 로그인 구현 후)
+        Long loginId=1L;
+        User user=userService.findUserById(loginId);
         CommunityBoard post= CommunityBoard.builder()
-                .title(communityBoardDto.getTitle()).content(communityBoardDto.getContent()).createdTime(LocalDateTime.now())
+                .title(communityBoardDto.getTitle()).content(communityBoardDto.getContent()).createdTime(LocalDateTime.now()).user(user)
                 .build();
         communityBoardService.savePost(post,communityBoardDto.getFiles());
         return new ResponseEntity<>("잡담 게시글 등록 성공", HttpStatus.CREATED);
@@ -44,13 +46,15 @@ public class CommunityController {
     @PostMapping("/{communityBoardId}/comments")
     public ResponseEntity<String> createCommunityComment(@PathVariable Long communityBoardId, @RequestBody CommunityCommentDto commentDto){
         //principal 추가
+        Long loginId=1L;
+        User user=userService.findUserById(loginId);
         CommunityBoard targetBoard=communityBoardService.findCommunityBoardEntity(communityBoardId);
         if(targetBoard==null){
             return new ResponseEntity<>("존재하지 않는 게시글에 대한 댓글 등록 요청",HttpStatus.NOT_FOUND);
         }
         CommunityComment comment=CommunityComment.builder()
                 .content(commentDto.getContent()).parentId(commentDto.getParentCommentId())
-                .createdTime(LocalDateTime.now()).communityBoard(targetBoard)
+                .createdTime(LocalDateTime.now()).communityBoard(targetBoard).user(user)
                 .build();
         commentService.saveCommunityComment(comment, commentDto.getParentCommentId());
         return new ResponseEntity<>("잡담 게시판 댓글 등록 성공",HttpStatus.CREATED);
@@ -70,7 +74,7 @@ public class CommunityController {
     }
 
     @GetMapping("")
-    public ResponseEntity<AllBoardResponseWithPageCount> getAllCommunityBoards(@PageableDefault(size=3, sort="id", direction = Sort.Direction.DESC) Pageable pageable,
+    public ResponseEntity<AllBoardResponseWithPageCount> getAllCommunityBoards(@PageableDefault(sort="id", direction = Sort.Direction.DESC) Pageable pageable,
                                                                                @RequestParam(required = false) String q){
         return new ResponseEntity<>(communityBoardService.getAllResponsesOfCommunityBoard(pageable,q),HttpStatus.OK);
     }

--- a/src/main/java/com/example/backend/community/domain/CommunityBoard.java
+++ b/src/main/java/com/example/backend/community/domain/CommunityBoard.java
@@ -58,10 +58,11 @@ public class CommunityBoard {
     private List<Report> reports=new ArrayList<>();
 
     @Builder
-    public CommunityBoard(String title, String content, LocalDateTime createdTime){
+    public CommunityBoard(String title, String content, LocalDateTime createdTime,User user){
         this.title=title;
         this.content=content;
         this.createdTime=createdTime;
+        this.user=user;
     }
 
     public void updateViewCount(){

--- a/src/main/java/com/example/backend/community/domain/CommunityComment.java
+++ b/src/main/java/com/example/backend/community/domain/CommunityComment.java
@@ -56,11 +56,12 @@ public class CommunityComment {
     private List<Report> reports=new ArrayList<>();
 
     @Builder
-    public CommunityComment(String content, Long parentId, LocalDateTime createdTime, CommunityBoard communityBoard){
+    public CommunityComment(String content, Long parentId, LocalDateTime createdTime, CommunityBoard communityBoard,User user){
         this.content=content;
         this.isParentComment= parentId==0;
         this.createdTime=createdTime;
         this.communityBoard=communityBoard;
+        this.user=user;
     }
 
 }

--- a/src/main/java/com/example/backend/community/repository/CustomCommunityRepository.java
+++ b/src/main/java/com/example/backend/community/repository/CustomCommunityRepository.java
@@ -1,9 +1,12 @@
 package com.example.backend.community.repository;
 
 import com.example.backend.community.domain.CommunityBoard;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
 public interface CustomCommunityRepository {
     List<CommunityBoard> findBestBoards();
+    Page<CommunityBoard> findAll(Pageable pageable, String[] queryList);
 }

--- a/src/main/java/com/example/backend/community/repository/CustomCommunityRepositoryImpl.java
+++ b/src/main/java/com/example/backend/community/repository/CustomCommunityRepositoryImpl.java
@@ -29,7 +29,8 @@ public class CustomCommunityRepositoryImpl implements CustomCommunityRepository{
     @Override
     public List<CommunityBoard> findBestBoards() {
         return jpaQueryFactory.selectFrom(communityBoard)
-                .orderBy(communityBoard.likeCount.desc())
+                .where(communityBoard.status.eq(true))
+                .orderBy(communityBoard.likeCount.desc(),communityBoard.id.desc())
                 .limit(5)
                 .fetch();
     }

--- a/src/main/java/com/example/backend/community/repository/CustomCommunityRepositoryImpl.java
+++ b/src/main/java/com/example/backend/community/repository/CustomCommunityRepositoryImpl.java
@@ -1,11 +1,21 @@
 package com.example.backend.community.repository;
 
 import com.example.backend.community.domain.CommunityBoard;
-import com.example.backend.community.domain.QCommunityBoard;
+import com.querydsl.core.QueryResults;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static com.example.backend.community.domain.QCommunityBoard.communityBoard;
@@ -14,6 +24,7 @@ import static com.example.backend.community.domain.QCommunityBoard.communityBoar
 @RequiredArgsConstructor
 public class CustomCommunityRepositoryImpl implements CustomCommunityRepository{
     private final JPAQueryFactory jpaQueryFactory;
+    private Sort sort;
 
     @Override
     public List<CommunityBoard> findBestBoards() {
@@ -22,4 +33,48 @@ public class CustomCommunityRepositoryImpl implements CustomCommunityRepository{
                 .limit(5)
                 .fetch();
     }
+
+    @Override
+    public Page<CommunityBoard> findAll(Pageable pageable, String[] queryList) {
+
+        QueryResults<CommunityBoard> queryResults = jpaQueryFactory.selectFrom(communityBoard)
+                .where(communityBoard.status.eq(true), getPredicate(queryList))
+                .orderBy(getOrders(pageable.getSort()).toArray(OrderSpecifier[]::new))
+                .offset(pageable.getOffset()) //시작 위치
+                .limit(pageable.getPageSize()) //한 페이지에 들어가는 데이터 개수만큼만 조회
+                .fetchResults();
+        return new PageImpl<>(queryResults.getResults(), pageable, queryResults.getTotal());
+
+    }
+
+
+    private BooleanExpression getPredicate(String[] queryList){
+        if(queryList==null)
+            return null;
+        return Expressions.anyOf(Arrays.stream(queryList).map(this::checkTitleAndContent).toArray(BooleanExpression[]::new));
+
+    }
+    
+    private BooleanExpression checkTitleAndContent(String q){
+        return communityBoard.title.contains(q).or(communityBoard.content.contains(q));
+    }
+
+    private List<OrderSpecifier> getOrders(Sort sort) {
+        List<OrderSpecifier> orders=new ArrayList<>();
+        for (Sort.Order order : sort) {
+            Order direction = order.getDirection().isAscending() ? Order.ASC : Order.DESC;
+            //likeCount, viewCount 로 정렬한 후 id로 내부에서재정렬
+            switch (order.getProperty()){
+                case "id":
+                    orders.add(new OrderSpecifier(direction,communityBoard.id));
+                    return orders;
+                case "likeCount":
+                    orders.add(new OrderSpecifier(direction,communityBoard.likeCount));
+                case "viewCount":
+                    orders.add(new OrderSpecifier(direction,communityBoard.viewCount));
+            }
+        }
+        return orders;
+    }
+
 }

--- a/src/main/java/com/example/backend/community/service/CommunityBoardService.java
+++ b/src/main/java/com/example/backend/community/service/CommunityBoardService.java
@@ -3,6 +3,7 @@ package com.example.backend.community.service;
 import com.example.backend.community.domain.CommunityBoard;
 import com.example.backend.community.domain.CommunityBoardImage;
 import com.example.backend.community.domain.CommunityComment;
+import com.example.backend.community.dto.AllBoardResponseWithPageCount;
 import com.example.backend.community.dto.AllCommunityBoardsResponse;
 import com.example.backend.community.dto.CommunityCommentsResponse;
 import com.example.backend.community.dto.DetailCommunityBoardResponse;
@@ -17,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -71,12 +73,6 @@ public class CommunityBoardService {
         return null;
     }
 
-    public int getTotalPageCount(){
-        List<CommunityBoard> communityBoards = communityBoardRepository.findAll()
-                .stream().filter(board->board.getStatus().equals(true)).collect(Collectors.toList());
-        return communityBoards.size()/10+1;
-    }
-
     public DetailCommunityBoardResponse getDetailBoardResponse(CommunityBoard communityBoard,Long loginId){
         List<CommunityComment> parentComments=communityBoard.getComments()
                         .stream()
@@ -92,8 +88,14 @@ public class CommunityBoardService {
         communityBoardRepository.save(board);
     }
 
-    public List<AllCommunityBoardsResponse> getAllResponsesOfCommunityBoard(Pageable pageable){
-        return toAllCommunityBoardResponse(communityBoardRepository.findAll(pageable).toList());
+    public AllBoardResponseWithPageCount getAllResponsesOfCommunityBoard(Pageable pageable, String query){
+        String[] queryList=null;
+        if(query!=null){
+            queryList= query.split(" ");
+        }
+        Page<CommunityBoard> boardPages = communityBoardRepository.findAll(pageable, queryList);
+        List<AllCommunityBoardsResponse> boardResponses = toAllCommunityBoardResponse(boardPages.getContent());
+        return new AllBoardResponseWithPageCount(boardPages.getTotalPages(), boardResponses);
     }
 
     public List<AllCommunityBoardsResponse> getBestResponseOfCommunityBoard(){


### PR DESCRIPTION
제목
---
잡담게시판 API (전체 게시글 조회, best 게시글 조회, 게시글 등록, 댓글 등록) 수정

상세 구현내용
---
전체 게시글 조회 API: 검색어별 조회 추가
BEST 게시글 조회 API: 삭제된 게시글 제외 조회하도록 수정
게시글, 댓글 등록 API: 로그인 된 현재 사용자 지정 (1번 사용자) 하여 게시글 등록 사용자 임시 매핑

작업사항
---
- [ ] 기능 추가
- [ ] 기능 수정
- [ ] 버그 수정
- [ ] 기타 설정

주의사항
---
잡담게시글, 댓글 등록시 1번 사용자로 등록되게 임시 지정 