### PR TITLE
✨ feat: 영상 등록, 등록용 사전작업 API

### DIFF
--- a/src/main/java/com/example/backend/security/WebSecurityConfig.java
+++ b/src/main/java/com/example/backend/security/WebSecurityConfig.java
@@ -14,6 +14,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
             ,"/signup","/signup/**","/signin","/signin/**"//소셜 로그인 관련한 부분도 추가
             ,"/test","/test-db","/test-db/**" //s3, rds 연동 테스트때 사용한 url 들 일단 접근 허가
             ,"/boards/community","/boards/community/**" //로그인 구현 전 잡담게시판 구현 위해 임시 허가
+            ,"/boards/video","/boards/video/**" //로그인 구현 전 영상게시판 구현 위해 임시허가
     };
 
     @Override

--- a/src/main/java/com/example/backend/video/VideoController.java
+++ b/src/main/java/com/example/backend/video/VideoController.java
@@ -1,0 +1,26 @@
+package com.example.backend.video;
+
+import com.example.backend.user.UserService;
+import com.example.backend.user.domain.User;
+import com.example.backend.video.dto.VideoDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/boards/video")
+@RequiredArgsConstructor
+public class VideoController {
+    private final VideoService videoService;
+    private final UserService userService;
+
+    @PostMapping("")
+    public ResponseEntity<String> uploadVideo(@RequestBody VideoDto videoDto){
+        Long loginId=1L;
+        User user = userService.findUserById(loginId);
+        videoService.saveVideo(videoDto,user);
+        return new ResponseEntity<>("영상 등록 성공", HttpStatus.CREATED);
+    }
+
+}

--- a/src/main/java/com/example/backend/video/VideoController.java
+++ b/src/main/java/com/example/backend/video/VideoController.java
@@ -15,6 +15,12 @@ public class VideoController {
     private final VideoService videoService;
     private final UserService userService;
 
+    @GetMapping("")
+    public ResponseEntity<String> verifyVideoUrl(@RequestParam String url){
+        String existence= videoService.checkVideoUrlExistence(url);
+        return new ResponseEntity<>(existence,HttpStatus.OK);
+    }
+
     @PostMapping("")
     public ResponseEntity<String> uploadVideo(@RequestBody VideoDto videoDto){
         Long loginId=1L;

--- a/src/main/java/com/example/backend/video/VideoController.java
+++ b/src/main/java/com/example/backend/video/VideoController.java
@@ -3,6 +3,7 @@ package com.example.backend.video;
 import com.example.backend.user.UserService;
 import com.example.backend.user.domain.User;
 import com.example.backend.video.dto.VideoDto;
+import com.example.backend.video.dto.VideoUploadInfoResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -19,6 +20,12 @@ public class VideoController {
     public ResponseEntity<String> verifyVideoUrl(@RequestParam String url){
         String existence= videoService.checkVideoUrlExistence(url);
         return new ResponseEntity<>(existence,HttpStatus.OK);
+    }
+
+    @GetMapping("/info/{userId}")
+    public ResponseEntity<VideoUploadInfoResponse> getInfoForVideoUpload(@PathVariable Long userId){
+        User user = userService.findUserById(userId);
+        return new ResponseEntity<>(videoService.getPreInfoForVideoUpload(user),HttpStatus.OK);
     }
 
     @PostMapping("")

--- a/src/main/java/com/example/backend/video/VideoService.java
+++ b/src/main/java/com/example/backend/video/VideoService.java
@@ -32,7 +32,8 @@ public class VideoService {
                 .originTitle(videoDto.getTitle()).series(series)
                 .episodeNumber(videoDto.getEpisode()).user(user)
                 .build();
-        video=toHourMinSec(video,videoDto.getRuntime());
+        int[] times = toHourMinSec(video, videoDto.getRuntime());
+        video.setVideoRuntime(times);
         List<Hashtag> hashtags = getHashtags(videoDto.getHashtags());
         if(hashtags!=null){
             saveVideoHashtag(video,hashtags);
@@ -72,7 +73,7 @@ public class VideoService {
     }
 
     //넘어오는 시간 형태 11:10:1 (시간) 11:10 (분) 00:04 (초)
-    private Video toHourMinSec(Video video, String runtime){
+    private int[] toHourMinSec(Video video, String runtime){
         String[] strings = runtime.split(":");
         int hour,min,sec;
         switch (strings.length){
@@ -91,7 +92,6 @@ public class VideoService {
                 min=0;
                 sec=0;
         }
-        video.setVideoRuntime(hour,min,sec);
-        return video;
+        return new int[]{hour, min, sec};
     }
 }

--- a/src/main/java/com/example/backend/video/VideoService.java
+++ b/src/main/java/com/example/backend/video/VideoService.java
@@ -2,12 +2,15 @@ package com.example.backend.video;
 
 import com.example.backend.user.domain.User;
 import com.example.backend.video.domain.*;
+import com.example.backend.video.dto.InnerInfoResponse;
 import com.example.backend.video.dto.VideoDto;
+import com.example.backend.video.dto.VideoUploadInfoResponse;
 import com.example.backend.video.repository.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -34,7 +37,7 @@ public class VideoService {
                 .build();
         int[] times = toHourMinSec(video, videoDto.getRuntime());
         video.setVideoRuntime(times);
-        List<Hashtag> hashtags = getHashtags(videoDto.getHashtags());
+        List<Hashtag> hashtags = getHashtagsByIds(videoDto.getHashtags());
         if(hashtags!=null){
             saveVideoHashtag(video,hashtags);
         }
@@ -44,7 +47,7 @@ public class VideoService {
         videoRepository.save(video);
     }
 
-    private List<Hashtag> getHashtags(List<Long> ids){
+    private List<Hashtag> getHashtagsByIds(List<Long> ids){
         if(ids==null){
             return null;
         }
@@ -100,5 +103,26 @@ public class VideoService {
         if(video==null)
             return "등록 가능";
         return "등록 불가능";
+    }
+
+    private List<InnerInfoResponse> findAllSeries(){
+        return seriesRepository.findAll().stream()
+                .map(InnerInfoResponse::new)
+                .collect(Collectors.toList());
+    }
+
+    private List<InnerInfoResponse> findAllHashtags(){
+        return hashtagRepository.findAll()
+                .stream()
+                .map(InnerInfoResponse::new)
+                .collect(Collectors.toList());
+    }
+
+    private List<InnerInfoResponse> findAllPlayListsOfUser(User user){
+        return new ArrayList<>();
+    }
+
+    public VideoUploadInfoResponse getPreInfoForVideoUpload(User user){
+        return VideoUploadInfoResponse.toInfoResponse(findAllSeries(),findAllHashtags(),findAllPlayListsOfUser(user));
     }
 }

--- a/src/main/java/com/example/backend/video/VideoService.java
+++ b/src/main/java/com/example/backend/video/VideoService.java
@@ -94,4 +94,11 @@ public class VideoService {
         }
         return new int[]{hour, min, sec};
     }
+
+    public String checkVideoUrlExistence(String url){
+        Video video = videoRepository.findByVideoUrl(url);
+        if(video==null)
+            return "등록 가능";
+        return "등록 불가능";
+    }
 }

--- a/src/main/java/com/example/backend/video/VideoService.java
+++ b/src/main/java/com/example/backend/video/VideoService.java
@@ -1,0 +1,97 @@
+package com.example.backend.video;
+
+import com.example.backend.user.domain.User;
+import com.example.backend.video.domain.*;
+import com.example.backend.video.dto.VideoDto;
+import com.example.backend.video.repository.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static java.lang.Integer.parseInt;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class VideoService {
+    private final VideoRepository videoRepository;
+    private final HashtagRepository hashtagRepository;
+    private final SeriesRepository seriesRepository;
+    private final VideoHashtagRepository videoTagRepository;
+    private final CustomHashtagRepository customHashtagRepository;
+
+    public void saveVideo(VideoDto videoDto, User user){
+        //플레이리스트에 영상 저장하는 부분 추가
+        Series series=getSeries(videoDto.getSeries());
+        Video video=Video.builder()
+                .videoUrl(videoDto.getUrl()).description(videoDto.getDescription())
+                .originTitle(videoDto.getTitle()).series(series)
+                .episodeNumber(videoDto.getEpisode()).user(user)
+                .build();
+        video=toHourMinSec(video,videoDto.getRuntime());
+        List<Hashtag> hashtags = getHashtags(videoDto.getHashtags());
+        if(hashtags!=null){
+            saveVideoHashtag(video,hashtags);
+        }
+        if(videoDto.getKeywords()!=null){
+            saveVideoKeywords(videoDto.getKeywords(),video);
+        }
+        videoRepository.save(video);
+    }
+
+    private List<Hashtag> getHashtags(List<Long> ids){
+        if(ids==null){
+            return null;
+        }
+        return ids.stream().map(id -> hashtagRepository.findById(id).get()).collect(Collectors.toList());
+    }
+
+    private void saveVideoHashtag(Video video,List<Hashtag> hashtags){
+        int order=1;
+        for(Hashtag hashtag:hashtags){
+            VideoHashtag videoHashtag = VideoHashtag.builder().video(video).hashtag(hashtag).order(order++).build();
+            videoTagRepository.save(videoHashtag);
+        }
+    }
+
+    private void saveVideoKeywords(List<String> keywords,Video video){
+        int order=1;
+        for(String keyword:keywords){
+            CustomHashtag videoKeyword = CustomHashtag.builder().video(video).name(keyword).order(order++).build();
+            customHashtagRepository.save(videoKeyword);
+        }
+    }
+
+    private Series getSeries(Long id){
+        Optional<Series> series = seriesRepository.findById(id);
+        return series.orElse(null);
+    }
+
+    //넘어오는 시간 형태 11:10:1 (시간) 11:10 (분) 00:04 (초)
+    private Video toHourMinSec(Video video, String runtime){
+        String[] strings = runtime.split(":");
+        int hour,min,sec;
+        switch (strings.length){
+            case 3:
+                hour= parseInt(strings[0]);
+                min= parseInt(strings[1]);
+                sec= parseInt(strings[2]);
+                break;
+            case 2:
+                hour=0;
+                min= parseInt(strings[0]);
+                sec= parseInt(strings[1]);
+                break;
+            default:
+                hour=0;
+                min=0;
+                sec=0;
+        }
+        video.setVideoRuntime(hour,min,sec);
+        return video;
+    }
+}

--- a/src/main/java/com/example/backend/video/domain/CustomHashtag.java
+++ b/src/main/java/com/example/backend/video/domain/CustomHashtag.java
@@ -1,0 +1,36 @@
+package com.example.backend.video.domain;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Data
+@Table
+@NoArgsConstructor
+public class CustomHashtag {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "custom_hashtag_id")
+    private Long id;
+
+    @Column(nullable = false, length = 15)
+    private String customHashtagName;
+
+    //1 비디오 - N 키워드
+    @ManyToOne
+    @JoinColumn(name = "video_id")
+    private Video video;
+
+    @Column(nullable = false)
+    private Integer tagOrder;
+
+    @Builder
+    public CustomHashtag(Video video, String name, int order){
+        this.video=video;
+        this.customHashtagName=name;
+        this.tagOrder=order;
+    }
+}

--- a/src/main/java/com/example/backend/video/domain/Hashtag.java
+++ b/src/main/java/com/example/backend/video/domain/Hashtag.java
@@ -1,0 +1,21 @@
+package com.example.backend.video.domain;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Data
+@Table
+@NoArgsConstructor
+public class Hashtag {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "hashtag_id")
+    private Long id;
+
+    @Column
+    private String hashtagName;
+
+}

--- a/src/main/java/com/example/backend/video/domain/Series.java
+++ b/src/main/java/com/example/backend/video/domain/Series.java
@@ -1,0 +1,20 @@
+package com.example.backend.video.domain;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Data
+@NoArgsConstructor
+@Table
+public class Series {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "series_id")
+    private Long id;
+
+    @Column
+    private String seriesName;
+}

--- a/src/main/java/com/example/backend/video/domain/Video.java
+++ b/src/main/java/com/example/backend/video/domain/Video.java
@@ -76,10 +76,10 @@ public class Video {
         this.user=user;
     }
 
-    public void setVideoRuntime(Integer hour, Integer min, Integer sec){
-        this.runtimeHour=hour;
-        this.runtimeMin=min;
-        this.runtimeSec=sec;
+    public void setVideoRuntime(int[] times){
+        this.runtimeHour=times[0];
+        this.runtimeMin=times[1];
+        this.runtimeSec=times[2];
     }
 
 }

--- a/src/main/java/com/example/backend/video/domain/Video.java
+++ b/src/main/java/com/example/backend/video/domain/Video.java
@@ -1,0 +1,85 @@
+package com.example.backend.video.domain;
+
+import com.example.backend.user.domain.User;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+
+import javax.persistence.*;
+import javax.persistence.criteria.CriteriaBuilder;
+import java.time.LocalDateTime;
+
+@Entity
+@Data
+@NoArgsConstructor
+@Table
+public class Video {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "video_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String originVideoTitle;
+
+    //20자 제한 주기
+    @Column
+    private String description;
+
+    //1 영상 - 1 시리즈 / 1 시리즈 - N 영상
+    @ManyToOne
+    @JoinColumn(name = "series_id")
+    private Series series;
+
+    //비디오 업로드한 사용자자
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String videoUrl;
+
+    @Column
+    private Integer episodeNumber;
+
+    @Column(nullable = false)
+    @CreatedDate
+    private LocalDateTime createdTime;
+
+    @Column
+    private Integer runtimeHour;
+
+    @Column
+    private Integer runtimeMin;
+
+    @Column
+    private Integer runtimeSec;
+
+    @Column(nullable = false)
+    private int likeCount=0;
+
+    @Column(nullable = false)
+    private int reportCount=0;
+
+    @Column(nullable = false)
+    private int viewCount=0;
+
+    @Builder
+    public Video (String originTitle, String description, String videoUrl, Integer episodeNumber, Series series,User user){
+        this.originVideoTitle=originTitle;
+        this.description=description;
+        this.videoUrl=videoUrl;
+        this.episodeNumber=episodeNumber;
+        this.series=series;
+        this.createdTime=LocalDateTime.now();
+        this.user=user;
+    }
+
+    public void setVideoRuntime(Integer hour, Integer min, Integer sec){
+        this.runtimeHour=hour;
+        this.runtimeMin=min;
+        this.runtimeSec=sec;
+    }
+
+}

--- a/src/main/java/com/example/backend/video/domain/VideoHashtag.java
+++ b/src/main/java/com/example/backend/video/domain/VideoHashtag.java
@@ -1,0 +1,39 @@
+package com.example.backend.video.domain;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Table
+@Data
+@NoArgsConstructor
+public class VideoHashtag {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "video_hashtag_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "hashtag_id")
+    private Hashtag hashtag;
+
+    @ManyToOne
+    @JoinColumn(name = "video_id")
+    private Video video;
+
+    @Column(nullable = false)
+    private int hashtagOrder;
+
+    @Column(nullable = false)
+    private Boolean status=true; //이 비디오-해시태그가 매핑되어 있다면 1, 수정 등으로 인해 매핑 해제시 0\
+
+    @Builder
+    public VideoHashtag(Video video, Hashtag hashtag, int order){
+        this.video=video;
+        this.hashtag=hashtag;
+        this.hashtagOrder=order;
+    }
+}

--- a/src/main/java/com/example/backend/video/dto/InnerInfoResponse.java
+++ b/src/main/java/com/example/backend/video/dto/InnerInfoResponse.java
@@ -1,0 +1,24 @@
+package com.example.backend.video.dto;
+
+import com.example.backend.video.domain.Hashtag;
+import com.example.backend.video.domain.Series;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class InnerInfoResponse {
+    private Long id;
+    private String name;
+
+    public InnerInfoResponse(Series series){
+        this.id=series.getId();
+        this.name=series.getSeriesName();
+    }
+
+    public InnerInfoResponse(Hashtag hashtag){
+        this.id=hashtag.getId();
+        this.name=hashtag.getHashtagName();
+    }
+}

--- a/src/main/java/com/example/backend/video/dto/VideoDto.java
+++ b/src/main/java/com/example/backend/video/dto/VideoDto.java
@@ -1,0 +1,20 @@
+package com.example.backend.video.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class VideoDto {
+    private String url;
+    private String title;
+    private String runtime;
+    private String description;
+    private Long series;
+    private Integer episode;
+    private List<Long> hashtags;
+    private List<String> keywords;
+    private List<Long> playlists;
+}

--- a/src/main/java/com/example/backend/video/dto/VideoUploadInfoResponse.java
+++ b/src/main/java/com/example/backend/video/dto/VideoUploadInfoResponse.java
@@ -1,0 +1,25 @@
+package com.example.backend.video.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+public class VideoUploadInfoResponse {
+    private List<InnerInfoResponse> series;
+    private List<InnerInfoResponse> hashtags;
+    private List<InnerInfoResponse> playlists;
+
+    public static VideoUploadInfoResponse toInfoResponse(List<InnerInfoResponse> series,List<InnerInfoResponse> hashtags, List<InnerInfoResponse> playlists){
+        return VideoUploadInfoResponse.builder()
+                .series(series)
+                .hashtags(hashtags)
+                .playlists(playlists)
+                .build();
+
+    }
+}

--- a/src/main/java/com/example/backend/video/repository/CustomHashtagRepository.java
+++ b/src/main/java/com/example/backend/video/repository/CustomHashtagRepository.java
@@ -1,0 +1,9 @@
+package com.example.backend.video.repository;
+
+import com.example.backend.video.domain.CustomHashtag;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CustomHashtagRepository extends JpaRepository<CustomHashtag, Long> {
+}

--- a/src/main/java/com/example/backend/video/repository/HashtagRepository.java
+++ b/src/main/java/com/example/backend/video/repository/HashtagRepository.java
@@ -1,0 +1,9 @@
+package com.example.backend.video.repository;
+
+import com.example.backend.video.domain.Hashtag;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface HashtagRepository extends JpaRepository<Hashtag, Long> {
+}

--- a/src/main/java/com/example/backend/video/repository/SeriesRepository.java
+++ b/src/main/java/com/example/backend/video/repository/SeriesRepository.java
@@ -1,0 +1,9 @@
+package com.example.backend.video.repository;
+
+import com.example.backend.video.domain.Series;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SeriesRepository extends JpaRepository<Series, Long> {
+}

--- a/src/main/java/com/example/backend/video/repository/VideoHashtagRepository.java
+++ b/src/main/java/com/example/backend/video/repository/VideoHashtagRepository.java
@@ -1,0 +1,9 @@
+package com.example.backend.video.repository;
+
+import com.example.backend.video.domain.VideoHashtag;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface VideoHashtagRepository extends JpaRepository<VideoHashtag, Long> {
+}

--- a/src/main/java/com/example/backend/video/repository/VideoRepository.java
+++ b/src/main/java/com/example/backend/video/repository/VideoRepository.java
@@ -1,0 +1,9 @@
+package com.example.backend.video.repository;
+
+import com.example.backend.video.domain.Video;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface VideoRepository extends JpaRepository<Video, Long> {
+}

--- a/src/main/java/com/example/backend/video/repository/VideoRepository.java
+++ b/src/main/java/com/example/backend/video/repository/VideoRepository.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface VideoRepository extends JpaRepository<Video, Long> {
+    Video findByVideoUrl(String url);
 }


### PR DESCRIPTION
제목
---
영상 게시글 등록 API 구현
영상 게시판용 엔티티 생성
영상 게시글 등록 전 URL 검증, 정보 조회 API 구현

상세 구현내용
---
Video, Hashtag, CustomHashtag, Series 엔티티 생성 -> 추후 CustomHashtag 위치 옮길 예정
영상 등록 API 구현, 등록 전 URL 검증 및 정보 조회 API 구현

작업사항
---
- [ ] 기능 추가
- [ ] 기능 수정
- [ ] 버그 수정
- [ ] 기타 설정

주의사항
---
플레이리스트 정보를 영상 등록 페이지에 함께 보내주어야하는데, 아직 영상 부분이 구현이 안되어서 플레이리스트가 없는 문제 
**영상 등록 구현이 완료되었으므로 우선 플레이리스트 데이터베이스를 생성해야 할 듯 함**
closes #14 