### PR TITLE
[HOTFIX]/[ADD] 댓글조회 수정, 크롤링 코드 추가, 전체영상 조회 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,8 @@ dependencies {
 //			"javax.annotation:javax.annotation-api",
 //			"com.querydsl:querydsl-apt:${queryDslVersion}:jpa")
 
+	implementation 'org.jsoup:jsoup:1.14.2'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/backend/community/service/CommunityBoardService.java
+++ b/src/main/java/com/example/backend/community/service/CommunityBoardService.java
@@ -75,7 +75,7 @@ public class CommunityBoardService {
 
     public DetailCommunityBoardResponse getDetailBoardResponse(CommunityBoard communityBoard,Long loginId){
         Long boardWriterId=communityBoard.getUser().getUserId();
-        List<CommunityComment> allComments= commentService.getAllCommentsOnBoard(communityBoard);
+        List<CommunityComment> allComments= communityBoard.getComments();
         List<CommunityComment> parentComments=allComments
                         .stream()
                         .filter(comment->comment.getIsParentComment().equals(true))

--- a/src/main/java/com/example/backend/video/VideoController.java
+++ b/src/main/java/com/example/backend/video/VideoController.java
@@ -81,7 +81,7 @@ public class VideoController {
     }
 
     @GetMapping("")
-    public ResponseEntity<AllVideoResponseWithPageCount> getAllVideos(@PageableDefault(size=4, sort="id",direction = Sort.Direction.DESC) Pageable pageable,
+    public ResponseEntity<AllVideoResponseWithPageCount> getAllVideos(@PageableDefault(size=8, sort="id",direction = Sort.Direction.DESC) Pageable pageable,
                                                                       @RequestParam(required = false) String tag, @RequestParam(required = false) String nickname, @RequestParam(required = false) String q){
         return new ResponseEntity<>(videoService.getAllVideosResponse(pageable, tag, nickname, q),HttpStatus.OK);
     }

--- a/src/main/java/com/example/backend/video/VideoController.java
+++ b/src/main/java/com/example/backend/video/VideoController.java
@@ -9,6 +9,8 @@ import com.example.backend.user.domain.User;
 import com.example.backend.video.domain.Video;
 import com.example.backend.video.domain.VideoComment;
 import com.example.backend.video.dto.*;
+import com.example.backend.video.service.VideoCommentService;
+import com.example.backend.video.service.VideoService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;

--- a/src/main/java/com/example/backend/video/repository/CustomVideoRepositoryImpl.java
+++ b/src/main/java/com/example/backend/video/repository/CustomVideoRepositoryImpl.java
@@ -39,11 +39,17 @@ public class CustomVideoRepositoryImpl implements CustomVideoRepository{
 
     @Override
     public Page<Video> findAll(Pageable pageable, List<String> tags, String nickname, List<String> queries) {
+        long pageOffset= pageable.getOffset()-4;
+        int pageSize = pageable.getPageSize();
+        if(pageable.getPageNumber()==0){
+            pageOffset=0;
+            pageSize=4;
+        }
         QueryResults<Video> results = jpaQueryFactory.selectFrom(video)
                 .where(video.status.eq(true), predicate(tags, nickname, queries))
                 .orderBy(order(pageable.getSort()).toArray(OrderSpecifier[]::new))
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
+                .offset(pageOffset)
+                .limit(pageSize)
                 .fetchResults();
 
         return new PageImpl<>(results.getResults(),pageable,results.getTotal());

--- a/src/main/java/com/example/backend/video/service/ProgramCrawler.java
+++ b/src/main/java/com/example/backend/video/service/ProgramCrawler.java
@@ -1,0 +1,147 @@
+package com.example.backend.video.service;
+
+import com.nimbusds.oauth2.sdk.util.date.SimpleDate;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+@Service
+public class ProgramCrawler {
+
+    public static void main(String[] args){
+
+        System.out.println("------------------KBS-----------------");
+        kbs();
+        System.out.println("------------------SBS-----------------");
+        sbs();
+        System.out.println("------------------MBC-----------------");
+        mbc(2); //2: 현재방송 / 3: 종영
+
+    }
+
+
+    private static List<String> sbs(){
+        String url1="https://apis.sbs.co.kr/main-api/section/tv?pgm_sct=ET&sort=new&offset=";
+        String url2="&limit=30";
+        int offset=0;
+        Document document = null;
+        List<String> sbsProgram=new ArrayList<>();
+        while(true){
+            String url=url1+offset+url2;
+            try {
+                String html= Jsoup.connect(url).
+                        ignoreContentType(true)
+                        .execute().body();
+                if(!html.contains("title"))
+                    break;
+                JSONArray array = new JSONArray(html);
+
+                for(int i=0;i<array.length();i++){
+                    JSONObject jsonObject = array.getJSONObject(i);
+                    sbsProgram.add(jsonObject.get("title").toString());
+                }
+
+                offset+=30;
+
+            } catch (IOException e) {
+                e.printStackTrace();
+                break;
+            }
+        }
+        return sbsProgram;
+    }
+
+    private static List<String> mbc(int state){
+        String url1="https://control.imbc.com/TV/Program?callback=Program_2_1_1_3_2_0_0_0_";
+        String url2="&subCategoryId=2&curPage=";
+        String url3="&pageSize=100&order=3&broadState="+state+"&endYear=0&initial=&genre=0";
+        int page=1;
+        SimpleDateFormat format=new SimpleDateFormat("yyyyMMdd");
+        String date= format.format(new Date());
+        Document document = null;
+        List<String> mbcProgram=new ArrayList<>();
+        while(true){
+            String url=url1+date+url2+page+url3;
+            try {
+                String html= Jsoup.connect(url).
+                        ignoreContentType(true)
+                        .execute().body();
+
+                if(!html.contains("Title"))
+                    break;
+
+                List<Integer> head = findIndexes("(", html);
+                List<Integer> tail = findIndexes(")", html);
+
+                String parsed=html.substring(head.get(0)+1,tail.get(tail.size()-1));
+                JSONObject jsnobject = new JSONObject(parsed);
+
+                JSONArray jsonArray = jsnobject.getJSONArray("List");
+                for (int i = 0; i < jsonArray.length(); i++) {
+                    JSONObject jsonObject = jsonArray.getJSONObject(i);
+                    String title=jsonObject.getString("Title");
+                    System.out.println("title = " + title);
+                    mbcProgram.add(title);
+                }
+                page++;
+
+            } catch (IOException e) {
+                e.printStackTrace();
+                break;
+            }
+        }
+        return mbcProgram;
+    }
+
+    private static List<String> kbs(){
+        String url1="https://pprogramapi.kbs.co.kr/api/v1/external/program?end_yn=n&section_code=04&page=";
+        String url2="&page_size=12&rtype=jsonp&show_yn=Y&sort_option=rdatetime%20desc&dict=Y&callback=section3";
+        int page=1;
+        Document document;
+        List<String> kbsProgram=new ArrayList<>();
+        while(true){
+            String url=url1+page+url2;
+            try {
+                document = Jsoup.connect(url).get();
+                Element body = document.body();
+                String html = body.html();
+                //title + 3 + 13 / program_day_of_week - 3
+                List<Integer> title = findIndexes("program_title", html);
+                List<Integer> program_day_of_week = findIndexes("official_sns_instagram", html);
+                if(title.isEmpty())
+                    break;
+                for(int i=0;i<title.size();i++){
+                    String programTitle=html.substring(title.get(i)+16, program_day_of_week.get(i)-3);
+                    System.out.println("programTitle = " + programTitle);
+                    kbsProgram.add(programTitle);
+                }
+                page++;
+
+            } catch (IOException e) {
+                e.printStackTrace();
+                break;
+            }
+        }
+        return kbsProgram;
+    }
+
+
+    private static List<Integer> findIndexes(String word, String document) {
+        List<Integer> indexList = new ArrayList<>();
+        int index = document.indexOf(word);
+        while(index != -1) {
+            indexList.add(index);
+            index = document.indexOf(word, index+word.length());
+        }
+        return indexList;
+    }
+}

--- a/src/main/java/com/example/backend/video/service/VideoCommentService.java
+++ b/src/main/java/com/example/backend/video/service/VideoCommentService.java
@@ -1,4 +1,4 @@
-package com.example.backend.video;
+package com.example.backend.video.service;
 
 import com.example.backend.video.domain.VideoComment;
 import com.example.backend.video.dto.VideoCommentsResponse;

--- a/src/main/java/com/example/backend/video/service/VideoService.java
+++ b/src/main/java/com/example/backend/video/service/VideoService.java
@@ -154,7 +154,7 @@ public class VideoService {
         Long videoWriterId=videoWriter.getUserId();
         List<VideoComment> parentComments = video.getVideoComments()
                 .stream()
-                .filter(comment -> comment.getStatus().equals(true) && comment.getIsParentComment().equals(true)) //status true고, 부모인 댓글만 넘김
+                .filter(comment -> comment.getIsParentComment().equals(true)) //부모댓글만 넘김
                 .collect(Collectors.toList());
         List<VideoCommentsResponse> videoCommentResponses = videoCommentService.getVideoCommentResponses(parentComments, loginId, videoWriterId);
         return DetailVideoResponse.fromEntity(video,videoCommentResponses,loginId,getHashtagKeywordStringInVideo(video));

--- a/src/main/java/com/example/backend/video/service/VideoService.java
+++ b/src/main/java/com/example/backend/video/service/VideoService.java
@@ -172,7 +172,13 @@ public class VideoService {
         }
         Page<Video> videoPage = videoRepository.findAll(pageable, tags, nickname, null);
         List<AllVideoResponse> allVideoResponses = toAllResponse(videoPage.getContent());
-        return new AllVideoResponseWithPageCount(allVideoResponses,videoPage.getTotalPages());
+        return new AllVideoResponseWithPageCount(allVideoResponses,getTotalPageCount(videoPage.getTotalElements()));
+    }
+
+    private int getTotalPageCount(long pages){
+        //total video count 를 기준으로 한 페이지는 4개 -> 다음페이지는 8개로 나뉜다는걸 생각해서 전체 페이지 수 반환
+        //데이터 13개 (의도: 3페이지, 잘못된 연산: 2페이지) 넣어놓고 체크해보면 될듯
+        return (int) (1+Math.ceil((pages-4)/(double)8));
     }
 
     private List<AllVideoResponse> toAllResponse(List<Video> videos){

--- a/src/main/java/com/example/backend/video/service/VideoService.java
+++ b/src/main/java/com/example/backend/video/service/VideoService.java
@@ -1,4 +1,4 @@
-package com.example.backend.video;
+package com.example.backend.video.service;
 
 import com.example.backend.customHashtag.CustomHashtag;
 import com.example.backend.customHashtag.CustomHashtagRepository;
@@ -6,6 +6,7 @@ import com.example.backend.user.domain.User;
 import com.example.backend.video.domain.*;
 import com.example.backend.video.dto.*;
 import com.example.backend.video.repository.*;
+import com.example.backend.video.service.VideoCommentService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;


### PR DESCRIPTION
제목
---
댓글 조회 방식 수정, 방송3사 프로그램명 크롤링 코드 추가
전체 영상게시글 조회 방식 수정

작업내용
---
- [x] 기능 추가
- [ ] 기능 수정
- [x] 버그 수정
- [ ] 기타 설정

수정내용
---
1. 방송3사 프로그램명 크롤링 코드 추가 (아직 주기적 실행 설정 X)
2. 상세 잡담게시글, 영상 게시글 조회 시 댓글 조회 방식 변경
> 기존: 삭제된 댓글은 아예 반환 X
>변경: 삭제된 댓글 중, "대댓글이 있는 댓글" 은 "삭제된 댓글" 명시한 상태로 조회
3. 전체 영상 게시글 조회 시, 첫 페이지는 영상 4개만 조회 이후 페이지는 영상 8개 씩 조회되도록 수정 및 전체 페이지 개수 수정

주의사항
---