### PR TITLE
[FEAT] 영상 예약 등록 / 시리즈 검색 API 구현

### DIFF
--- a/src/main/java/com/example/backend/reservation/ReservationController.java
+++ b/src/main/java/com/example/backend/reservation/ReservationController.java
@@ -1,5 +1,6 @@
 package com.example.backend.reservation;
 
+import com.example.backend.reservation.domain.ConfirmedReservation;
 import com.example.backend.reservation.domain.Reservation;
 import com.example.backend.reservation.dto.ReservationDto;
 import com.example.backend.user.UserService;
@@ -37,7 +38,22 @@ public class ReservationController {
                 .eTime(reservationDto.getEndTime())
                 .date(LocalDate.parse(reservationDto.getReservationDate()))
                 .build();
-        reservationService.saveReservation(reservation);
-        return new ResponseEntity<>("예약 등록 성공",HttpStatus.CREATED);
+        Reservation saveReservation = reservationService.saveReservation(reservation);
+        if(saveReservation!=null)
+            return new ResponseEntity<>("예약 등록 성공",HttpStatus.CREATED);
+        return new ResponseEntity<>("선택 불가능한 예약시간",HttpStatus.CONFLICT);
+    }
+
+    @PostMapping("/test")
+    public void saveConfirm(@RequestBody ReservationDto reservationDto){
+        Video video = videoService.findVideoEntityById(reservationDto.getId());
+        ConfirmedReservation build = ConfirmedReservation.builder()
+                .video(video)
+                .startTime(reservationDto.getStartTime())
+                .endTime(reservationDto.getEndTime())
+                .date(LocalDate.parse(reservationDto.getReservationDate()))
+                .build();
+
+        reservationService.saveConfirm(build);
     }
 }

--- a/src/main/java/com/example/backend/reservation/ReservationController.java
+++ b/src/main/java/com/example/backend/reservation/ReservationController.java
@@ -6,16 +6,16 @@ import com.example.backend.reservation.dto.ReservationDto;
 import com.example.backend.user.UserService;
 import com.example.backend.user.domain.User;
 import com.example.backend.video.domain.Video;
+import com.example.backend.reservation.dto.VideoTitleSearchResponse;
 import com.example.backend.video.service.VideoService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/run/reservations")
@@ -69,5 +69,15 @@ public class ReservationController {
                 .build();
 
         reservationService.saveConfirm(build);
+    }
+
+    @GetMapping("/title/search")
+    public ResponseEntity<List<VideoTitleSearchResponse>> findVideoContainingTitle(@RequestParam String q){
+        List<Video> videos = videoService.findVideoContainingTitle(q, "likeCount");
+        List<VideoTitleSearchResponse> searchResponses = videos.stream()
+                .map(VideoTitleSearchResponse::fromEntity)
+                .limit(5)
+                .collect(Collectors.toList());
+        return new ResponseEntity<>(searchResponses,HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/backend/reservation/ReservationService.java
+++ b/src/main/java/com/example/backend/reservation/ReservationService.java
@@ -5,6 +5,7 @@ import com.example.backend.reservation.domain.Reservation;
 import com.example.backend.reservation.repository.ConfirmedReservationRepository;
 import com.example.backend.reservation.repository.ReservationRepository;
 import com.example.backend.video.domain.Video;
+import com.example.backend.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.apache.tomcat.jni.Local;
 import org.springframework.stereotype.Service;
@@ -15,7 +16,9 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -23,20 +26,15 @@ public class ReservationService {
     private final ReservationRepository reservationRepository;
     private final ConfirmedReservationRepository confirmedRepository;
 
-    public Reservation saveReservation(Reservation reservation){
-        Boolean available = checkReservationAvailability(reservation);
-        System.out.println("available = " + available);
-        Reservation made=null;
-        if(available)
-            made=reservationRepository.save(reservation);
-        return made;
+    public void saveReservation(Reservation reservation){
+        reservationRepository.save(reservation);
     }
 
     public void saveConfirm(ConfirmedReservation confirm){
         confirmedRepository.save(confirm);
     }
 
-    public Boolean checkReservationAvailability(Reservation reservation){
+    public Boolean checkReservationConflict(Reservation reservation){
         LocalDate date=reservation.getReservationDate();
         String sTime=reservation.getStartTime();
         String eTime=reservation.getEndTime();
@@ -57,21 +55,51 @@ public class ReservationService {
         Date finalStart = start;
         Date finalEnd = end;
 
+        //예약 확정 내역들 -> 각각 startTime, endTime 으로 mapping
+        //그 값들에 대해 filter 적용
         //forEach -> filter 되나?
+
+        //compareTo: 같으면 0, 이후 날짜면 양수, 이전 날짜면 음수
+
+//        Optional<ConfirmedReservation> match = confirms.stream()
+//                .filter(confirm -> {
+//                    try {
+//                        return (finalStart.before(toDate(confirm.getReservationDate(), confirm.getEndTime()))&&(finalStart.after(toDate(confirm.getReservationDate(), confirm.getStartTime()))||finalStart.equals(toDate(confirm.getReservationDate(),confirm.getStartTime()))))
+//                                || ((finalEnd.before((toDate(confirm.getReservationDate(), confirm.getEndTime())))||finalEnd.equals(toDate(confirm.getReservationDate(),confirm.getEndTime())))&&finalEnd.after(toDate(confirm.getReservationDate(), confirm.getStartTime())))
+//                                || (finalStart.before(toDate(confirm.getReservationDate(), confirm.getStartTime()))&&finalEnd.after(toDate(confirm.getReservationDate(), confirm.getEndTime())));
+//                    } catch (ParseException e) {
+//                        e.printStackTrace();
+//                    }
+//                    return false;
+//                })
+//                .findFirst();
+
         Optional<ConfirmedReservation> match = confirms.stream()
                 .filter(confirm -> {
                     try {
-                        return finalStart.before(toDate(confirm.getReservationDate(), confirm.getEndTime()))&&finalStart.after(toDate(confirm.getReservationDate(), confirm.getStartTime()))
-                                || finalEnd.before(toDate(confirm.getReservationDate(), confirm.getEndTime()))&&finalEnd.after(toDate(confirm.getReservationDate(), confirm.getStartTime()))
-                                || finalStart.before(toDate(confirm.getReservationDate(), confirm.getStartTime()))&&finalEnd.after(toDate(confirm.getReservationDate(), confirm.getEndTime()));
+                        return (finalStart.before(toDate(confirm.getReservationDate(), confirm.getEndTime())) && (finalStart.compareTo(toDate(confirm.getReservationDate(), confirm.getStartTime())) >= 0))
+                                || (finalEnd.compareTo(toDate(confirm.getReservationDate(), confirm.getEndTime())) <= 0 && finalEnd.after(toDate(confirm.getReservationDate(), confirm.getStartTime())))
+                                || (finalStart.before(toDate(confirm.getReservationDate(), confirm.getStartTime())) && finalEnd.after(toDate(confirm.getReservationDate(), confirm.getEndTime())));
                     } catch (ParseException e) {
                         e.printStackTrace();
                     }
                     return false;
                 })
                 .findFirst();
-        return match.isEmpty();
+        return match.isPresent(); //충돌되는거 있으면 true, 아니면 false 반환
 
+    }
+
+    public Reservation findReservationByDateAndVideoAndUser(LocalDate date, Video video, User user){
+        List<Reservation> reservations = reservationRepository.findByReservationDateAndVideo(date, video);
+        Optional<Reservation> foundReservation = reservations.stream()
+                .filter(reservation -> reservation.getUser().equals(user))
+                .findFirst();
+        return foundReservation.orElse(null);
+    }
+
+    public ConfirmedReservation findConfirmedReservation(LocalDate date, Video video, String start, String end){
+        return confirmedRepository.findByReservationDateAndStartTimeAndEndTimeAndVideo(date, start, end, video);
     }
 
     private Date toDate(LocalDate date, String time) throws ParseException{
@@ -80,21 +108,10 @@ public class ReservationService {
         return form.parse(reservationDate+time);
     }
 
-    public void calcEndTime(int hour, int min, Video video){
-        Integer runtimeHour = video.getRuntimeHour();
-        Integer runtimeMin = video.getRuntimeMin();
-        Integer runtimeSec = video.getRuntimeSec();
-        hour+=runtimeHour;
-        if(runtimeSec>0){
-            runtimeMin++;
-        }
-        if(runtimeMin>0){
-            min+=(runtimeMin+9)/10*10;
-        }
-        if(min>60){
-            hour++;
-            min-=60;
-        }
-
+    private Boolean checkDatetimeAvailability(String option,ConfirmedReservation confirm, Date reservationTime, String timeOption) throws ParseException {
+        String confirmTime=timeOption.equals("start")?confirm.getStartTime():confirm.getEndTime();
+        Date confirmedDate=toDate(confirm.getReservationDate(), confirmTime);
+        return option.equals("before")?reservationTime.before(confirmedDate):reservationTime.after(confirmedDate);
     }
+
 }

--- a/src/main/java/com/example/backend/reservation/ReservationService.java
+++ b/src/main/java/com/example/backend/reservation/ReservationService.java
@@ -1,33 +1,100 @@
 package com.example.backend.reservation;
 
+import com.example.backend.reservation.domain.ConfirmedReservation;
 import com.example.backend.reservation.domain.Reservation;
+import com.example.backend.reservation.repository.ConfirmedReservationRepository;
 import com.example.backend.reservation.repository.ReservationRepository;
+import com.example.backend.video.domain.Video;
 import lombok.RequiredArgsConstructor;
+import org.apache.tomcat.jni.Local;
 import org.springframework.stereotype.Service;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class ReservationService {
     private final ReservationRepository reservationRepository;
+    private final ConfirmedReservationRepository confirmedRepository;
 
-    public void saveReservation(Reservation reservation){
-        reservationRepository.save(reservation);
+    public Reservation saveReservation(Reservation reservation){
+        Boolean available = checkReservationAvailability(reservation);
+        System.out.println("available = " + available);
+        Reservation made=null;
+        if(available)
+            made=reservationRepository.save(reservation);
+        return made;
     }
 
-//    private void confirmReservation(Reservation reservation){
-//        Integer startHour = reservation.getStartHour();
-//        Integer startMin = reservation.getStartMin();
-//        Integer endHour = reservation.getEndHour();
-//        Integer endMin = reservation.getEndMin();
-//        //시작시간, 종료시간 기준으로 모든 예약 내역 돌면서 동일 시간에 해당하는 예약 내역 찾기
-//    }
-//
-//    public Boolean checkReservationAvailability(Reservation reservation){
-//        //확정된 예약 내역을 따로 저장해주어야 하는데,,,,, (하루동안만 유지)
-//        // 1) 캐시서버 2) 데이터베이스 테이블
-//        Integer startHour = reservation.getStartHour();
-//        Integer startMin = reservation.getStartMin();
-//        Integer endHour = reservation.getEndHour();
-//        Integer endMin = reservation.getEndMin();
-//    }
+    public void saveConfirm(ConfirmedReservation confirm){
+        confirmedRepository.save(confirm);
+    }
+
+    public Boolean checkReservationAvailability(Reservation reservation){
+        LocalDate date=reservation.getReservationDate();
+        String sTime=reservation.getStartTime();
+        String eTime=reservation.getEndTime();
+
+
+        Date start;
+        Date end;
+        try {
+            start = toDate(date,sTime);
+            end=toDate(date,eTime);
+        } catch (ParseException e) {
+            e.printStackTrace();
+            return false;
+        }
+        List<ConfirmedReservation> confirms = confirmedRepository.findAllByReservationDate(date);
+        //시작시간이 둘 사이 / 종료시간이 둘 사이
+
+        Date finalStart = start;
+        Date finalEnd = end;
+
+        //forEach -> filter 되나?
+        Optional<ConfirmedReservation> match = confirms.stream()
+                .filter(confirm -> {
+                    try {
+                        return finalStart.before(toDate(confirm.getReservationDate(), confirm.getEndTime()))&&finalStart.after(toDate(confirm.getReservationDate(), confirm.getStartTime()))
+                                || finalEnd.before(toDate(confirm.getReservationDate(), confirm.getEndTime()))&&finalEnd.after(toDate(confirm.getReservationDate(), confirm.getStartTime()))
+                                || finalStart.before(toDate(confirm.getReservationDate(), confirm.getStartTime()))&&finalEnd.after(toDate(confirm.getReservationDate(), confirm.getEndTime()));
+                    } catch (ParseException e) {
+                        e.printStackTrace();
+                    }
+                    return false;
+                })
+                .findFirst();
+        return match.isEmpty();
+
+    }
+
+    private Date toDate(LocalDate date, String time) throws ParseException{
+        SimpleDateFormat form=new SimpleDateFormat("yy-MM-ddHH:mm");
+        String reservationDate=date.toString();
+        return form.parse(reservationDate+time);
+    }
+
+    public void calcEndTime(int hour, int min, Video video){
+        Integer runtimeHour = video.getRuntimeHour();
+        Integer runtimeMin = video.getRuntimeMin();
+        Integer runtimeSec = video.getRuntimeSec();
+        hour+=runtimeHour;
+        if(runtimeSec>0){
+            runtimeMin++;
+        }
+        if(runtimeMin>0){
+            min+=(runtimeMin+9)/10*10;
+        }
+        if(min>60){
+            hour++;
+            min-=60;
+        }
+
+    }
 }

--- a/src/main/java/com/example/backend/reservation/dto/VideoTitleSearchResponse.java
+++ b/src/main/java/com/example/backend/reservation/dto/VideoTitleSearchResponse.java
@@ -1,0 +1,31 @@
+package com.example.backend.reservation.dto;
+
+import com.example.backend.video.domain.Video;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class VideoTitleSearchResponse {
+    private Long id;
+    private String title;
+    private String url;
+    private Integer runtimeHour;
+    private Integer runtimeMin;
+    private Integer runtimeSec;
+
+    public static VideoTitleSearchResponse fromEntity(Video video){
+        return VideoTitleSearchResponse.builder()
+                .id(video.getId())
+                .title(video.getDescription())
+                .url(video.getVideoUrl())
+                .runtimeHour(video.getRuntimeHour())
+                .runtimeMin(video.getRuntimeMin())
+                .runtimeSec(video.getRuntimeSec())
+                .build();
+    }
+
+
+}

--- a/src/main/java/com/example/backend/reservation/repository/ConfirmedReservationRepository.java
+++ b/src/main/java/com/example/backend/reservation/repository/ConfirmedReservationRepository.java
@@ -1,6 +1,7 @@
 package com.example.backend.reservation.repository;
 
 import com.example.backend.reservation.domain.ConfirmedReservation;
+import com.example.backend.video.domain.Video;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,4 +11,5 @@ import java.util.List;
 @Repository
 public interface ConfirmedReservationRepository extends JpaRepository<ConfirmedReservation, Long> {
     List<ConfirmedReservation> findAllByReservationDate(LocalDate date);
+    ConfirmedReservation findByReservationDateAndStartTimeAndEndTimeAndVideo(LocalDate date, String startTime, String endTime, Video video);
 }

--- a/src/main/java/com/example/backend/reservation/repository/ConfirmedReservationRepository.java
+++ b/src/main/java/com/example/backend/reservation/repository/ConfirmedReservationRepository.java
@@ -4,6 +4,10 @@ import com.example.backend.reservation.domain.ConfirmedReservation;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
+import java.util.List;
+
 @Repository
 public interface ConfirmedReservationRepository extends JpaRepository<ConfirmedReservation, Long> {
+    List<ConfirmedReservation> findAllByReservationDate(LocalDate date);
 }

--- a/src/main/java/com/example/backend/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/example/backend/reservation/repository/ReservationRepository.java
@@ -1,9 +1,15 @@
 package com.example.backend.reservation.repository;
 
 import com.example.backend.reservation.domain.Reservation;
+import com.example.backend.user.domain.User;
+import com.example.backend.video.domain.Video;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
+import java.util.List;
+
 @Repository
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+    List<Reservation> findByReservationDateAndVideo(LocalDate date, Video video);
 }

--- a/src/main/java/com/example/backend/video/VideoController.java
+++ b/src/main/java/com/example/backend/video/VideoController.java
@@ -6,6 +6,7 @@ import com.example.backend.report.Report;
 import com.example.backend.report.ReportService;
 import com.example.backend.user.UserService;
 import com.example.backend.user.domain.User;
+import com.example.backend.video.domain.Series;
 import com.example.backend.video.domain.Video;
 import com.example.backend.video.domain.VideoComment;
 import com.example.backend.video.dto.*;
@@ -158,6 +159,11 @@ public class VideoController {
             return new ResponseEntity<>("신고 5번 누적으로 삭제",HttpStatus.OK);
         }
         return new ResponseEntity<>("영상 댓글 신고 성공",HttpStatus.OK);
+    }
+
+    @GetMapping("/series/search")
+    public ResponseEntity<List<Series>> searchSeriesName(@RequestParam String q){
+        return new ResponseEntity<>(videoService.findSeriesNameByQuery(q),HttpStatus.OK);
     }
 
 

--- a/src/main/java/com/example/backend/video/repository/CustomVideoRepository.java
+++ b/src/main/java/com/example/backend/video/repository/CustomVideoRepository.java
@@ -9,4 +9,5 @@ import java.util.List;
 public interface CustomVideoRepository {
     Page<Video> findAll(Pageable pageable, List<String> tags, String nickname, List<String> queries);
     List<Video> findBestVideos();
+    List<Video> findTitleLike(String searchTitle, String order);
 }

--- a/src/main/java/com/example/backend/video/repository/CustomVideoRepositoryImpl.java
+++ b/src/main/java/com/example/backend/video/repository/CustomVideoRepositoryImpl.java
@@ -2,7 +2,6 @@ package com.example.backend.video.repository;
 
 import com.example.backend.customHashtag.CustomHashtag;
 import com.example.backend.customHashtag.QCustomHashtag;
-import com.example.backend.video.domain.Hashtag;
 import com.example.backend.video.domain.QVideoHashtag;
 import com.example.backend.video.domain.Video;
 import com.example.backend.video.domain.VideoHashtag;
@@ -35,6 +34,18 @@ public class CustomVideoRepositoryImpl implements CustomVideoRepository{
                 .orderBy(video.likeCount.desc(), video.id.desc())
                 .limit(4)
                 .fetch();
+    }
+
+    @Override
+    public List<Video> findTitleLike(String searchTitle,String order) {
+        OrderSpecifier orderSpecifier = new OrderSpecifier(Order.DESC, video.id);
+        if(order.equals("id"))
+            orderSpecifier=new OrderSpecifier(Order.DESC,video.likeCount);
+        return jpaQueryFactory.selectFrom(video)
+                .where(video.status.eq(true), video.description.contains(searchTitle))
+                .orderBy(orderSpecifier) //좋아요순 정렬
+                .fetch();
+
     }
 
     @Override

--- a/src/main/java/com/example/backend/video/repository/SeriesRepository.java
+++ b/src/main/java/com/example/backend/video/repository/SeriesRepository.java
@@ -2,8 +2,13 @@ package com.example.backend.video.repository;
 
 import com.example.backend.video.domain.Series;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface SeriesRepository extends JpaRepository<Series, Long> {
+    //param 을 안붙이고 하면 Parameter value [\] match type error 발생 -> hibernate 오류라고 함 (spring boot 2.6.8 에서 해결)
+    List<Series> findBySeriesNameContains(@Param("nameSearch") String nameSearch);
 }

--- a/src/main/java/com/example/backend/video/service/VideoService.java
+++ b/src/main/java/com/example/backend/video/service/VideoService.java
@@ -197,4 +197,8 @@ public class VideoService {
         videoRepository.save(video);
     }
 
+    public List<Series> findSeriesNameByQuery(String q){
+        return seriesRepository.findBySeriesNameContains(q);
+    }
+
 }

--- a/src/main/java/com/example/backend/video/service/VideoService.java
+++ b/src/main/java/com/example/backend/video/service/VideoService.java
@@ -201,4 +201,9 @@ public class VideoService {
         return seriesRepository.findBySeriesNameContains(q);
     }
 
+    public List<Video> findVideoContainingTitle(String searchTitle,String order){
+        //order: id 라면? 최신순 / likeCount 라면? 좋아요순
+        return videoRepository.findTitleLike(searchTitle,order);
+    }
+
 }


### PR DESCRIPTION
제목
---
영상 예약 등록 API, 시리즈 검색 API 구현

작업내용 
---
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 버그 수정
- [ ] 기타 설정

수정내용
---
1. 영상 예약 등록 API 구현 - 상황에 따른 response 반환

- 이미 해당 사용자가 동일 영상을 당일에 예약한 기록이 있음 : 중복 예약 불가
- 이미 동일 영상이 동일 시간에 예약 확정 : 이미 확정된 예약 존재
- 등록하려는 예약이 다른 예약 확정 시간과 겹친다면 : 선택 불가능한 시간
- 잘못된 영상을 예약 등록 요청 : 잘못된 영상에 대한 요청
- 이 외: 예약 성공

2. 영상 예악 등록 - 제목 검색 API 구현
- 현재: 최신순 5개 반환, 좋아요 순 5개로 수정 가능

3. 영상 게시글 작성 - 시리즈 검색 API 구현
- 검색어를 포함하는 모든 시리즈 반환

주의사항
---

