### PR TITLE
[FEAT] 예약 조회 API

### DIFF
--- a/src/main/java/com/example/backend/reservation/ReservationController.java
+++ b/src/main/java/com/example/backend/reservation/ReservationController.java
@@ -2,6 +2,7 @@ package com.example.backend.reservation;
 
 import com.example.backend.reservation.domain.ConfirmedReservation;
 import com.example.backend.reservation.domain.Reservation;
+import com.example.backend.reservation.dto.BestReservationResponse;
 import com.example.backend.reservation.dto.ReservationDto;
 import com.example.backend.reservation.dto.TimetableResponse;
 import com.example.backend.user.UserService;
@@ -77,5 +78,11 @@ public class ReservationController {
 //        System.out.println("start = " + start + ", end = " + end + ", select = " + select+", date = "+date);
         //시간 순 정렬
         return new ResponseEntity<>(reservationService.test(start, end, select, date),HttpStatus.OK);
+    }
+
+    @GetMapping("/best")
+    public ResponseEntity<List<BestReservationResponse>> getBest3Reservations(){
+        //오늘 날짜 -> group by 해서 예약 수 기준으로 정렬 -> limit 3
+        return new ResponseEntity<>(reservationService.getBestReservations(),HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/backend/reservation/ReservationController.java
+++ b/src/main/java/com/example/backend/reservation/ReservationController.java
@@ -87,4 +87,9 @@ public class ReservationController {
     public ResponseEntity<List<ConfirmedReservationResponse>> getConfirmedReservation(@RequestParam String date){
         return new ResponseEntity<>(reservationService.findAllConfirmedReservationsByDate(LocalDate.parse(date)),HttpStatus.OK);
     }
+
+    @GetMapping("/next")
+    public ResponseEntity<NextRunResponse> getNextRunReservation(){
+        return new ResponseEntity<>(reservationService.findNextConfirm(),HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/example/backend/reservation/ReservationController.java
+++ b/src/main/java/com/example/backend/reservation/ReservationController.java
@@ -2,13 +2,10 @@ package com.example.backend.reservation;
 
 import com.example.backend.reservation.domain.ConfirmedReservation;
 import com.example.backend.reservation.domain.Reservation;
-import com.example.backend.reservation.dto.BestReservationResponse;
-import com.example.backend.reservation.dto.ReservationDto;
-import com.example.backend.reservation.dto.TimetableResponse;
+import com.example.backend.reservation.dto.*;
 import com.example.backend.user.UserService;
 import com.example.backend.user.domain.User;
 import com.example.backend.video.domain.Video;
-import com.example.backend.reservation.dto.VideoTitleSearchResponse;
 import com.example.backend.video.service.VideoService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -84,5 +81,10 @@ public class ReservationController {
     public ResponseEntity<List<BestReservationResponse>> getBest3Reservations(){
         //오늘 날짜 -> group by 해서 예약 수 기준으로 정렬 -> limit 3
         return new ResponseEntity<>(reservationService.getBestReservations(),HttpStatus.OK);
+    }
+
+    @GetMapping("/confirm")
+    public ResponseEntity<List<ConfirmedReservationResponse>> getConfirmedReservation(@RequestParam String date){
+        return new ResponseEntity<>(reservationService.findAllConfirmedReservationsByDate(LocalDate.parse(date)),HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/backend/reservation/ReservationService.java
+++ b/src/main/java/com/example/backend/reservation/ReservationService.java
@@ -3,6 +3,7 @@ package com.example.backend.reservation;
 import com.example.backend.reservation.domain.ConfirmedReservation;
 import com.example.backend.reservation.domain.Reservation;
 import com.example.backend.reservation.dto.BestReservationResponse;
+import com.example.backend.reservation.dto.ConfirmedReservationResponse;
 import com.example.backend.reservation.dto.ReservationCountDto;
 import com.example.backend.reservation.dto.TimetableResponse;
 import com.example.backend.reservation.repository.ConfirmedReservationRepository;
@@ -90,6 +91,13 @@ public class ReservationService {
 
     public ConfirmedReservation findConfirmedReservation(LocalDate date, Video video, String start, String end){
         return confirmedRepository.findByReservationDateAndStartTimeAndEndTimeAndVideo(date, start, end, video);
+    }
+
+    public List<ConfirmedReservationResponse> findAllConfirmedReservationsByDate(LocalDate date){
+        return confirmedRepository.findAllByReservationDate(date)
+                .stream()
+                .map(ConfirmedReservationResponse::of)
+                .collect(Collectors.toList());
     }
 
     private Date toDate(LocalDate date, String time) throws ParseException{

--- a/src/main/java/com/example/backend/reservation/ReservationService.java
+++ b/src/main/java/com/example/backend/reservation/ReservationService.java
@@ -3,7 +3,7 @@ package com.example.backend.reservation;
 import com.example.backend.reservation.domain.ConfirmedReservation;
 import com.example.backend.reservation.domain.Reservation;
 import com.example.backend.reservation.dto.BestReservationResponse;
-import com.example.backend.reservation.dto.TestDto;
+import com.example.backend.reservation.dto.ReservationCountDto;
 import com.example.backend.reservation.dto.TimetableResponse;
 import com.example.backend.reservation.repository.ConfirmedReservationRepository;
 import com.example.backend.reservation.repository.ReservationRepository;
@@ -15,7 +15,6 @@ import org.springframework.stereotype.Service;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -129,7 +128,7 @@ public class ReservationService {
                 .map(this::toDate)
                 .collect(Collectors.toList());
 
-        List<TestDto> groupVideo = reservationRepository.getDateReservationGroupVideo(localDate);
+        List<ReservationCountDto> groupVideo = reservationRepository.getDateReservationGroupVideo(localDate);
 
         return groupVideo
                 .stream()
@@ -156,7 +155,7 @@ public class ReservationService {
 //        now = LocalDate.parse(s);
         return reservationRepository.getDateReservationGroupVideo(now)
                 .stream()
-                .sorted(Comparator.comparing(TestDto::getCount).reversed())
+                .sorted(Comparator.comparing(ReservationCountDto::getCount).reversed())
                 .limit(3)
                 .map(g -> BestReservationResponse.of(g.getReservation(), g.getCount()))
                 .collect(Collectors.toList());

--- a/src/main/java/com/example/backend/reservation/ReservationService.java
+++ b/src/main/java/com/example/backend/reservation/ReservationService.java
@@ -2,6 +2,7 @@ package com.example.backend.reservation;
 
 import com.example.backend.reservation.domain.ConfirmedReservation;
 import com.example.backend.reservation.domain.Reservation;
+import com.example.backend.reservation.dto.BestReservationResponse;
 import com.example.backend.reservation.dto.TestDto;
 import com.example.backend.reservation.dto.TimetableResponse;
 import com.example.backend.reservation.repository.ConfirmedReservationRepository;
@@ -147,6 +148,18 @@ public class ReservationService {
     private Boolean filterSelection(List<Date> selects, Date start, Date end){
         return selects.stream()
                 .anyMatch(select->start.compareTo(select)<=0&&end.compareTo(select)>=0);
+    }
+
+    public List<BestReservationResponse> getBestReservations(){
+        LocalDate now = LocalDate.now();
+//        String s="2022-05-26";
+//        now = LocalDate.parse(s);
+        return reservationRepository.getDateReservationGroupVideo(now)
+                .stream()
+                .sorted(Comparator.comparing(TestDto::getCount).reversed())
+                .limit(3)
+                .map(g -> BestReservationResponse.of(g.getReservation(), g.getCount()))
+                .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/com/example/backend/reservation/ReservationService.java
+++ b/src/main/java/com/example/backend/reservation/ReservationService.java
@@ -122,7 +122,7 @@ public class ReservationService {
 //        List<Reservation> confirmNeeded = reservationRepository.getReservationsConfirmNeeded(date, criteria);
         reservationRepository.getReservationsConfirmNeeded(date, criteria)
                 .stream()
-                .filter(reservation -> findConfirmedReservation(reservation.getReservationDate(), reservation.getVideo(), reservation.getStartTime(), reservation.getEndTime()) == null)
+                .filter(r -> findConfirmedReservation(r.getReservation().getReservationDate(), r.getReservation().getVideo(), r.getReservation().getStartTime(), r.getReservation().getEndTime()) == null)
                 .map(ConfirmedReservation::new)
                 .forEach(this::saveConfirm);
 

--- a/src/main/java/com/example/backend/reservation/domain/ConfirmedReservation.java
+++ b/src/main/java/com/example/backend/reservation/domain/ConfirmedReservation.java
@@ -1,5 +1,6 @@
 package com.example.backend.reservation.domain;
 
+import com.example.backend.reservation.dto.ReservationCountDto;
 import com.example.backend.video.domain.Video;
 import lombok.Builder;
 import lombok.Data;
@@ -31,11 +32,17 @@ public class ConfirmedReservation {
     @Column(nullable = false)
     private String endTime;
 
-    public ConfirmedReservation(Reservation reservation){
+    @Column
+    private Long reservationCount;
+
+    public ConfirmedReservation(ReservationCountDto dto){
+        Reservation reservation = dto.getReservation();
+        Long count = dto.getCount();
         this.reservationDate=reservation.getReservationDate();
         this.startTime=reservation.getStartTime();
         this.endTime=reservation.getEndTime();
         this.video=reservation.getVideo();
+        this.reservationCount=count;
     }
 
 

--- a/src/main/java/com/example/backend/reservation/dto/BestReservationResponse.java
+++ b/src/main/java/com/example/backend/reservation/dto/BestReservationResponse.java
@@ -1,0 +1,34 @@
+package com.example.backend.reservation.dto;
+
+import com.example.backend.reservation.domain.Reservation;
+import com.example.backend.video.domain.Video;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class BestReservationResponse {
+    private Long id;
+    private String title;
+    private String runTime;
+    private String videoUrl;
+    private Long count;
+    private String reservationDate;
+    private String startTime;
+    private String endTime;
+
+    public static BestReservationResponse of(Reservation reservation, Long count){
+        Video video = reservation.getVideo();
+        return BestReservationResponse.builder()
+                .id(video.getId()).title(video.getDescription())
+                .runTime(video.getRuntimeHour()+":"+video.getRuntimeMin()+":"+video.getRuntimeSec())
+                .videoUrl(video.getVideoUrl())
+                .count(count)
+                .reservationDate(reservation.getReservationDate().toString())
+                .startTime(reservation.getStartTime())
+                .endTime(reservation.getEndTime())
+                .build();
+    }
+}

--- a/src/main/java/com/example/backend/reservation/dto/ConfirmedReservationResponse.java
+++ b/src/main/java/com/example/backend/reservation/dto/ConfirmedReservationResponse.java
@@ -1,0 +1,31 @@
+package com.example.backend.reservation.dto;
+
+import com.example.backend.reservation.domain.ConfirmedReservation;
+import com.example.backend.video.domain.Video;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class ConfirmedReservationResponse {
+    private Long reservationId;
+    private Long videoId;
+    private String title;
+    private String reservationDate;
+    private String startTime;
+    private String endTime;
+
+    public static ConfirmedReservationResponse of(ConfirmedReservation res){
+        Video video = res.getVideo();
+        return ConfirmedReservationResponse.builder()
+                .reservationId(res.getId())
+                .videoId(video.getId())
+                .title(video.getDescription())
+                .reservationDate(res.getReservationDate().toString())
+                .startTime(res.getStartTime())
+                .endTime(res.getEndTime())
+                .build();
+    }
+}

--- a/src/main/java/com/example/backend/reservation/dto/NextRunResponse.java
+++ b/src/main/java/com/example/backend/reservation/dto/NextRunResponse.java
@@ -1,0 +1,35 @@
+package com.example.backend.reservation.dto;
+
+import com.example.backend.reservation.domain.ConfirmedReservation;
+import com.example.backend.video.domain.Video;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class NextRunResponse {
+    private Long reservationId;
+    private Long videoId;
+    private String title;
+    private String runTime;
+    private String videoUrl;
+    private Long count;
+    private String reservationDate;
+    private String startTime;
+
+    public static NextRunResponse of(ConfirmedReservation res){
+        Video video = res.getVideo();
+        return NextRunResponse.builder()
+                .reservationId(res.getId())
+                .videoId(video.getId())
+                .title(video.getDescription())
+                .runTime(video.getRuntimeHour()+":"+video.getRuntimeMin()+":"+video.getRuntimeSec())
+                .videoUrl(video.getVideoUrl())
+                .count(res.getReservationCount())
+                .reservationDate(res.getReservationDate().toString())
+                .startTime(res.getStartTime())
+                .build();
+    }
+}

--- a/src/main/java/com/example/backend/reservation/dto/ReservationCountDto.java
+++ b/src/main/java/com/example/backend/reservation/dto/ReservationCountDto.java
@@ -10,7 +10,7 @@ import lombok.Setter;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
-public class TestDto {
+public class ReservationCountDto {
     private Reservation reservation;
     private Long count;
 }

--- a/src/main/java/com/example/backend/reservation/repository/ConfirmedReservationRepository.java
+++ b/src/main/java/com/example/backend/reservation/repository/ConfirmedReservationRepository.java
@@ -12,4 +12,5 @@ import java.util.List;
 public interface ConfirmedReservationRepository extends JpaRepository<ConfirmedReservation, Long> {
     List<ConfirmedReservation> findAllByReservationDate(LocalDate date);
     ConfirmedReservation findByReservationDateAndStartTimeAndEndTimeAndVideo(LocalDate date, String startTime, String endTime, Video video);
+    List<ConfirmedReservation> findAllByReservationDateGreaterThanEqual(LocalDate date);
 }

--- a/src/main/java/com/example/backend/reservation/repository/CustomReservationRepository.java
+++ b/src/main/java/com/example/backend/reservation/repository/CustomReservationRepository.java
@@ -1,12 +1,12 @@
 package com.example.backend.reservation.repository;
 
 import com.example.backend.reservation.domain.Reservation;
-import com.example.backend.reservation.dto.TestDto;
+import com.example.backend.reservation.dto.ReservationCountDto;
 
 import java.time.LocalDate;
 import java.util.List;
 
 public interface CustomReservationRepository {
     List<Reservation> getReservationsConfirmNeeded(LocalDate criteriaDate, Long confirmCriteria);
-    List<TestDto> getDateReservationGroupVideo(LocalDate date);
+    List<ReservationCountDto> getDateReservationGroupVideo(LocalDate date);
 }

--- a/src/main/java/com/example/backend/reservation/repository/CustomReservationRepository.java
+++ b/src/main/java/com/example/backend/reservation/repository/CustomReservationRepository.java
@@ -7,6 +7,6 @@ import java.time.LocalDate;
 import java.util.List;
 
 public interface CustomReservationRepository {
-    List<Reservation> getReservationsConfirmNeeded(LocalDate criteriaDate, Long confirmCriteria);
+    List<ReservationCountDto> getReservationsConfirmNeeded(LocalDate criteriaDate, Long confirmCriteria);
     List<ReservationCountDto> getDateReservationGroupVideo(LocalDate date);
 }

--- a/src/main/java/com/example/backend/reservation/repository/CustomReservationRepositoryImpl.java
+++ b/src/main/java/com/example/backend/reservation/repository/CustomReservationRepositoryImpl.java
@@ -17,9 +17,10 @@ public class CustomReservationRepositoryImpl implements CustomReservationReposit
 
 
     @Override
-    public List<Reservation> getReservationsConfirmNeeded(LocalDate criteriaDate, Long confirmCount) {
+    public List<ReservationCountDto> getReservationsConfirmNeeded(LocalDate criteriaDate, Long confirmCount) {
         return jpaQueryFactory
-                .selectFrom(reservation)
+                .select(Projections.fields(ReservationCountDto.class, reservation.as("reservation"), reservation.count().as("count")))
+                .from(reservation)
                 .where(reservation.reservationDate.goe(criteriaDate)) //날짜가 오늘 날짜 이후 (이전 날짜는 업데이트 필요 없음)
                 .groupBy(reservation.reservationDate, reservation.video, reservation.startTime, reservation.endTime)
                 .having(reservation.count().goe(confirmCount))

--- a/src/main/java/com/example/backend/reservation/repository/CustomReservationRepositoryImpl.java
+++ b/src/main/java/com/example/backend/reservation/repository/CustomReservationRepositoryImpl.java
@@ -1,7 +1,7 @@
 package com.example.backend.reservation.repository;
 
 import com.example.backend.reservation.domain.Reservation;
-import com.example.backend.reservation.dto.TestDto;
+import com.example.backend.reservation.dto.ReservationCountDto;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -27,10 +27,10 @@ public class CustomReservationRepositoryImpl implements CustomReservationReposit
     }
 
     @Override
-    public List<TestDto> getDateReservationGroupVideo(LocalDate date) {
+    public List<ReservationCountDto> getDateReservationGroupVideo(LocalDate date) {
         //여기서 날짜, 시작시간, 종료시간, 영상으로 같은 비디오 다 groupBy 해주고 그 결과에서 startTIme, endTime 비교해서 선택시간만 반환
         return jpaQueryFactory
-                .select(Projections.fields(TestDto.class, reservation.as("reservation"), reservation.count().as("count")))
+                .select(Projections.fields(ReservationCountDto.class, reservation.as("reservation"), reservation.count().as("count")))
                 .from(reservation)
                 .where(reservation.reservationDate.eq(date))
                 .groupBy(reservation.reservationDate, reservation.video, reservation.startTime, reservation.endTime)


### PR DESCRIPTION
제목
---
영상 달리기 예약 - 예약 조회 API 구현

작업내용
---
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 버그 수정
- [ ] 기타 설정

수정내용
---
1. 인기 예약 영상 탑 3 조회 API 구현 (당일 날짜 기준)
2. 확정 예약 조회 API 구현 (당일 날짜 기준, 별도 정렬 X)
3. 다음 달리기 예약 조회 API 구현 (현재 시간 기준)
- 지금 재생중인 영상 있을 경우: 해당 확정 예약 정보 반환
- 지금 시간 이후 확정된 예약이 있을 경우: 가장 빠른 예약 정보 반환
- 지금 시간 이후 확정된 예약 없을 경우: null 반환

주의사항
---
예약 종료 시간이 다음 날짜로 넘어가는 경우 (2022-06-04 23:50 ~ 2022-06-05 00:10) 처리 안되어있음
closes #31 