### PR TITLE
[HOTFIX] 영상 예약 등록 - 한 사용자 하루 한 번만 예약 가능

### DIFF
--- a/src/main/java/com/example/backend/reservation/ReservationController.java
+++ b/src/main/java/com/example/backend/reservation/ReservationController.java
@@ -61,7 +61,7 @@ public class ReservationController {
 
     @GetMapping("/title/search")
     public ResponseEntity<List<VideoTitleSearchResponse>> findVideoContainingTitle(@RequestParam String q){
-        List<Video> videos = videoService.findVideoContainingTitle(q, "likeCount");
+        List<Video> videos = videoService.findVideoContainingTitle(q, "id");
         List<VideoTitleSearchResponse> searchResponses = videos.stream()
                 .map(VideoTitleSearchResponse::fromEntity)
                 .limit(5)
@@ -90,6 +90,8 @@ public class ReservationController {
 
     @GetMapping("/next")
     public ResponseEntity<NextRunResponse> getNextRunReservation(){
+        //오늘 저녁 ~ 다음날 새벽 가능하던가?
+        //이게 되면 if(todate(startTime) > toDate(endTime) -> (startTime의 date + 하루),endTime 을 toDate 로 변환!
         return new ResponseEntity<>(reservationService.findNextConfirm(),HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/backend/reservation/ReservationController.java
+++ b/src/main/java/com/example/backend/reservation/ReservationController.java
@@ -38,7 +38,7 @@ public class ReservationController {
                 .eTime(reservationDto.getEndTime())
                 .date(date)
                 .build();
-        boolean existence= reservationService.findReservationByDateAndVideoAndUser(date, video, user)!=null; //존재하면 true, 아니면 false
+        boolean existence= reservationService.findReservationByDateAndUser(date, user)!=null; //존재하면 true, 아니면 false
 
         boolean hasConfirmed=reservationService.findConfirmedReservation(date,video,reservationDto.getStartTime(),reservationDto.getEndTime())!=null; //존재하면 true, 아니면 flase
         if(hasConfirmed){

--- a/src/main/java/com/example/backend/reservation/ReservationService.java
+++ b/src/main/java/com/example/backend/reservation/ReservationService.java
@@ -59,12 +59,9 @@ public class ReservationService {
     }
 
     //날짜, 사용자, 영상으로 예약 찾기 -> 당일 중복 예약 막기
-    public Reservation findReservationByDateAndVideoAndUser(LocalDate date, Video video, User user){
-        List<Reservation> reservations = reservationRepository.findByReservationDateAndVideo(date, video);
-        Optional<Reservation> foundReservation = reservations.stream()
-                .filter(reservation -> reservation.getUser().equals(user))
-                .findFirst();
-        return foundReservation.orElse(null);
+    //한 사용자 - 하루에 하나의 영상만 예약! => findReservationByDateAndUser 로 변경
+    public Reservation findReservationByDateAndUser(LocalDate date, User user){
+        return reservationRepository.findByReservationDateAndUser(date, user).orElse(null);
     }
 
     public ConfirmedReservation findConfirmedReservation(LocalDate date, Video video, String start, String end){

--- a/src/main/java/com/example/backend/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/example/backend/reservation/repository/ReservationRepository.java
@@ -8,8 +8,9 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ReservationRepository extends JpaRepository<Reservation, Long>,CustomReservationRepository {
-    List<Reservation> findByReservationDateAndVideo(LocalDate date, Video video);
+    Optional<Reservation> findByReservationDateAndUser(LocalDate date, User user);
 }

--- a/src/main/java/com/example/backend/video/repository/CustomVideoRepositoryImpl.java
+++ b/src/main/java/com/example/backend/video/repository/CustomVideoRepositoryImpl.java
@@ -39,7 +39,7 @@ public class CustomVideoRepositoryImpl implements CustomVideoRepository{
     @Override
     public List<Video> findTitleLike(String searchTitle,String order) {
         OrderSpecifier orderSpecifier = new OrderSpecifier(Order.DESC, video.id);
-        if(order.equals("id"))
+        if(order.equals("likeCount"))
             orderSpecifier=new OrderSpecifier(Order.DESC,video.likeCount);
         return jpaQueryFactory.selectFrom(video)
                 .where(video.status.eq(true), video.description.contains(searchTitle))


### PR DESCRIPTION
제목
---
영상 예약 등록 - 중복 예약 조건 수정
fixes #41  

작업내용
---
- [ ] 기능 추가
- [ ] 기능 수정
- [ ] 버그 수정
- [ ] 기타 설정

수정내용
---
- 기존: 한 사용자 - 하루 하나의 영상 중복 예약 불가 (동일 날짜로 다른 영상은 예약 가능)
- 수정: 한 사용자 - 하루 단 하나의 영상만 예약 가능 (이미 해당 날짜에 예약 내역이 있다면 다른 날짜로 예약해야함)

주의사항
---
예약 내역, 확정 예약 내역 데이터베이스 초기화
