### PR TITLE
[FEAT/FIX] 플레이리스트 API (3) , 플레이리스트 영상 관리 

### DIFF
--- a/src/main/java/com/example/backend/playlist/PlaylistController.java
+++ b/src/main/java/com/example/backend/playlist/PlaylistController.java
@@ -6,6 +6,9 @@ import com.example.backend.playlist.dto.*;
 import com.example.backend.user.UserService;
 import com.example.backend.user.domain.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -73,7 +76,13 @@ public class PlaylistController {
             return new ResponseEntity<>("권한 없음",HttpStatus.FORBIDDEN);
         Boolean changedStatus = playlistService.modifyPublicStatus(playlist);
         return new ResponseEntity<>(changedStatus?"공개":"비공개",HttpStatus.OK);
+    }
 
+    @GetMapping("")
+    public ResponseEntity<AllPlaylistResponseWithPageCount> getAllPlaylists(@PageableDefault(size=12, sort="id",direction = Sort.Direction.DESC) Pageable pageable,
+                                                                            @RequestParam(required = false) String title,
+                                                                            @RequestParam(required = false) String video){
+        return new ResponseEntity<>(playlistService.getAllPlaylists(pageable, title, video),HttpStatus.OK);
     }
 
 }

--- a/src/main/java/com/example/backend/playlist/PlaylistController.java
+++ b/src/main/java/com/example/backend/playlist/PlaylistController.java
@@ -58,4 +58,16 @@ public class PlaylistController {
 
     }
 
+    @PatchMapping("/{playlistId}")
+    public ResponseEntity<String> changePlaylistPublic(@PathVariable Long playlistId){
+        Long loginId=1L;
+        User user = userService.findUserById(loginId);
+        Playlist playlist = playlistService.findPlaylistEntity(playlistId);
+        if(!playlistService.checkUserPlaylistAuthority(user,playlist))
+            return new ResponseEntity<>("권한 없음",HttpStatus.FORBIDDEN);
+        Boolean changedStatus = playlistService.modifyPublicStatus(playlist);
+        return new ResponseEntity<>(changedStatus?"공개":"비공개",HttpStatus.OK);
+
+    }
+
 }

--- a/src/main/java/com/example/backend/playlist/PlaylistController.java
+++ b/src/main/java/com/example/backend/playlist/PlaylistController.java
@@ -28,7 +28,14 @@ public class PlaylistController {
 
     @PostMapping("/{playlistId}")
     public ResponseEntity<String> addVideoToPlaylist(@PathVariable Long playlistId, @RequestBody AddVideoDto dto){
-        playlistService.addVideoToPlaylist(dto.getVideoId(),playlistId);
+        Long loginId=1L;
+        User user = userService.findUserById(loginId);
+        Playlist playlist = playlistService.findPlaylistEntity(playlistId);
+        if(!playlistService.checkUserPlaylistAuthority(user,playlist))
+            return new ResponseEntity<>("권한 없음",HttpStatus.FORBIDDEN);
+        if(playlistService.checkVideoPlaylistExistence(dto.getVideoId(),playlist))
+            return new ResponseEntity<>("이미 해당 플레이리스트에 추가된 영상",HttpStatus.CONFLICT);
+        playlistService.addVideoToPlaylist(dto.getVideoId(),playlist);
         return new ResponseEntity<>("영상 추가 성공",HttpStatus.CREATED);
     }
 
@@ -55,7 +62,6 @@ public class PlaylistController {
         Long loginId=1L;
         User user = userService.findUserById(loginId);
         return new ResponseEntity<>(playlistService.getUserSavedPlaylists(user),HttpStatus.OK);
-
     }
 
     @PatchMapping("/{playlistId}")

--- a/src/main/java/com/example/backend/playlist/PlaylistService.java
+++ b/src/main/java/com/example/backend/playlist/PlaylistService.java
@@ -106,4 +106,14 @@ public class PlaylistService {
                 .collect(Collectors.toList());
     }
 
+    public Boolean modifyPublicStatus(Playlist playlist){
+        playlist.modifyPlaylistPublicStatus();
+        Playlist changedPlaylist = playlistRepository.save(playlist);
+        return changedPlaylist.getIsPublic();
+    }
+
+    public Boolean checkUserPlaylistAuthority(User user, Playlist playlist){
+        return playlist.getUser().equals(user);
+    }
+
 }

--- a/src/main/java/com/example/backend/playlist/PlaylistService.java
+++ b/src/main/java/com/example/backend/playlist/PlaylistService.java
@@ -3,9 +3,7 @@ package com.example.backend.playlist;
 import com.example.backend.playlist.domain.Playlist;
 import com.example.backend.playlist.domain.PlaylistVideo;
 import com.example.backend.playlist.domain.UserSavedPlaylist;
-import com.example.backend.playlist.dto.MyPlaylistResponse;
-import com.example.backend.playlist.dto.NewEmptyPlaylistDto;
-import com.example.backend.playlist.dto.PlaylistTitleResponse;
+import com.example.backend.playlist.dto.*;
 import com.example.backend.playlist.repository.PlaylistRepository;
 import com.example.backend.playlist.repository.PlaylistVideoRepository;
 import com.example.backend.playlist.repository.UserSavedPlaylistRepository;
@@ -15,9 +13,12 @@ import com.example.backend.video.repository.VideoRepository;
 import com.example.backend.video.service.VideoService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -110,6 +111,7 @@ public class PlaylistService {
                 .status(true)
                 .build();
         savedPlaylistRepository.save(userSavedPlaylist);
+        playlist.updateSaveCount();
     }
 
     private List<UserSavedPlaylist> findAllSavedPlaylistByUser(User user){

--- a/src/main/java/com/example/backend/playlist/PlaylistService.java
+++ b/src/main/java/com/example/backend/playlist/PlaylistService.java
@@ -41,8 +41,7 @@ public class PlaylistService {
         return MyPlaylistResponse.fromEntity(saved);
     }
 
-    public void addVideoToPlaylist(Long videoId, Long playlistId){
-        Playlist playlist = playlistRepository.findById(playlistId).orElse(null);
+    public void addVideoToPlaylist(Long videoId, Playlist playlist){
         Video video = videoService.findVideoEntityById(videoId);
         Integer lastVideoOrder = pvRepository.findLastVideoOrder(playlist);
         PlaylistVideo playlistVideo = PlaylistVideo.builder()
@@ -51,6 +50,12 @@ public class PlaylistService {
                 .order(lastVideoOrder != null ? ++lastVideoOrder : 1)
                 .build();
         pvRepository.save(playlistVideo);
+    }
+
+    public Boolean checkVideoPlaylistExistence(Long videoId, Playlist playlist){
+        Video video = videoService.findVideoEntityById(videoId);
+        PlaylistVideo playlistVideo = pvRepository.findByVideoAndPlaylist(video, playlist).orElse(null);
+        return playlistVideo!=null&&playlistVideo.getStatus();
     }
 
     private List<Playlist> findAllUserPlaylist(User user){

--- a/src/main/java/com/example/backend/playlist/domain/Playlist.java
+++ b/src/main/java/com/example/backend/playlist/domain/Playlist.java
@@ -56,5 +56,9 @@ public class Playlist {
         this.title=title;
     }
 
+    public void modifyPlaylistPublicStatus(){
+        this.isPublic=!this.isPublic;
+    }
+
 
 }

--- a/src/main/java/com/example/backend/playlist/domain/Playlist.java
+++ b/src/main/java/com/example/backend/playlist/domain/Playlist.java
@@ -41,6 +41,9 @@ public class Playlist {
     @Column(nullable = false)
     private int viewCount=0;
 
+    @Column(nullable = false)
+    private int saveCount=0;
+
     @Column(nullable = false, name = "playlist_status")
     private Boolean status=true;
 
@@ -59,6 +62,8 @@ public class Playlist {
     public void modifyPlaylistPublicStatus(){
         this.isPublic=!this.isPublic;
     }
+
+    public void updateSaveCount(){this.saveCount++;}
 
 
 }

--- a/src/main/java/com/example/backend/playlist/dto/AllPlaylistResponseWithPageCount.java
+++ b/src/main/java/com/example/backend/playlist/dto/AllPlaylistResponseWithPageCount.java
@@ -1,0 +1,18 @@
+package com.example.backend.playlist.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class AllPlaylistResponseWithPageCount {
+    Integer totalPageCount;
+    List<AllPlaylistsResponse> playlistsResponses;
+
+    public AllPlaylistResponseWithPageCount(int count, List<AllPlaylistsResponse> boards){
+        this.totalPageCount=count;
+        this.playlistsResponses=boards;
+    }
+}

--- a/src/main/java/com/example/backend/playlist/dto/AllPlaylistsResponse.java
+++ b/src/main/java/com/example/backend/playlist/dto/AllPlaylistsResponse.java
@@ -1,0 +1,23 @@
+package com.example.backend.playlist.dto;
+
+import lombok.*;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+public class AllPlaylistsResponse {
+    private Long id;
+    private String title;
+    private String titleImageUrl;
+    private String writerNickname;
+    private Integer likeCount;
+    private Integer saveCount;
+    private Integer videoCount;
+
+    public void updateData(String thumbnailUrl, Integer videoCount){
+        this.titleImageUrl=thumbnailUrl;
+        this.videoCount=videoCount;
+    }
+
+}

--- a/src/main/java/com/example/backend/playlist/repository/CustomPlaylistRepository.java
+++ b/src/main/java/com/example/backend/playlist/repository/CustomPlaylistRepository.java
@@ -1,0 +1,11 @@
+package com.example.backend.playlist.repository;
+
+import com.example.backend.playlist.dto.AllPlaylistsResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface CustomPlaylistRepository {
+    Page<AllPlaylistsResponse> findAllPlaylistsWithPageable(Pageable pageable, String title, String videoTitle);
+}

--- a/src/main/java/com/example/backend/playlist/repository/CustomPlaylistRepositoryImpl.java
+++ b/src/main/java/com/example/backend/playlist/repository/CustomPlaylistRepositoryImpl.java
@@ -1,0 +1,79 @@
+package com.example.backend.playlist.repository;
+
+import com.example.backend.playlist.dto.AllPlaylistsResponse;
+import com.querydsl.core.QueryResults;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.example.backend.playlist.domain.QPlaylist.playlist;
+import static com.example.backend.playlist.domain.QPlaylistVideo.playlistVideo;
+
+@RequiredArgsConstructor
+public class CustomPlaylistRepositoryImpl implements CustomPlaylistRepository {
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Page<AllPlaylistsResponse> findAllPlaylistsWithPageable(Pageable pageable, String title, String videoTitle) {
+        long pageOffset= pageable.getOffset()-4; //첫 페이지: 8개, 다음 페이지: 12개
+        int pageSize = pageable.getPageSize();
+        if(pageable.getPageNumber()==0){
+            pageOffset=0;
+            pageSize=8; //첫 페이지만 8개 조회
+        }
+        QueryResults<AllPlaylistsResponse> results = jpaQueryFactory.select(Projections.fields(AllPlaylistsResponse.class,
+                        playlist.id.as("id"), playlist.title.as("title"),
+                        playlist.user.nickname.as("writerNickname"), playlist.likeCount.as("likeCount"), playlist.saveCount.as("saveCount")))
+                .from(playlist)
+                .where(containsTitle(title), containsVideo(videoTitle), playlist.status.eq(true), playlist.isPublic.eq(true))
+                .orderBy(order(pageable.getSort()).toArray(OrderSpecifier[]::new))
+                .offset(pageOffset)
+                .limit(pageSize)
+                .fetchResults();
+
+        return new PageImpl<>(results.getResults(),pageable, results.getTotal());
+    }
+
+    private BooleanExpression containsTitle(String title){
+        if(title==null||title.isEmpty())
+            return null;
+        return playlist.title.contains(title);
+    }
+
+    private BooleanExpression containsVideo(String title){
+        if(title==null||title.isEmpty())
+            return null;
+        return playlist.videos.any().video.description.contains(title);
+    }
+
+    private List<OrderSpecifier> order(Sort sort){
+        List<OrderSpecifier> orders=new ArrayList<>();
+        Order direction= Order.DESC;
+        for(Sort.Order order : sort){
+            String orderProperty = order.getProperty();
+            switch (orderProperty){
+                case "id":
+                    orders.add(new OrderSpecifier(direction,playlist.id));
+                    return orders;
+                case "likeCount":
+                    orders.add(new OrderSpecifier(direction,playlist.likeCount));
+                    break;
+                case "saveCount":
+                    orders.add(new OrderSpecifier(direction,playlist.saveCount));
+                    break;
+            }
+        }
+        return orders;
+    }
+
+}

--- a/src/main/java/com/example/backend/playlist/repository/CustomPlaylistVideoRepository.java
+++ b/src/main/java/com/example/backend/playlist/repository/CustomPlaylistVideoRepository.java
@@ -4,4 +4,5 @@ import com.example.backend.playlist.domain.Playlist;
 
 public interface CustomPlaylistVideoRepository {
     Integer findLastVideoOrder(Playlist playlist);
+    String findFirstThumbnailUrl(Playlist playlist);
 }

--- a/src/main/java/com/example/backend/playlist/repository/CustomPlaylistVideoRepositoryImpl.java
+++ b/src/main/java/com/example/backend/playlist/repository/CustomPlaylistVideoRepositoryImpl.java
@@ -16,6 +16,6 @@ public class CustomPlaylistVideoRepositoryImpl implements CustomPlaylistVideoRep
                 .from(playlistVideo)
                 .where(playlistVideo.playlist.eq(playlist),playlistVideo.status.eq(true))
                 .orderBy(playlistVideo.videoOrder.desc())
-                .fetchOne();
+                .fetchFirst();
     }
 }

--- a/src/main/java/com/example/backend/playlist/repository/CustomPlaylistVideoRepositoryImpl.java
+++ b/src/main/java/com/example/backend/playlist/repository/CustomPlaylistVideoRepositoryImpl.java
@@ -18,4 +18,13 @@ public class CustomPlaylistVideoRepositoryImpl implements CustomPlaylistVideoRep
                 .orderBy(playlistVideo.videoOrder.desc())
                 .fetchFirst();
     }
+
+    @Override
+    public String findFirstThumbnailUrl(Playlist playlist) {
+        return jpaQueryFactory.select(playlistVideo.video.thumbnailUrl)
+                .from(playlistVideo)
+                .where(playlistVideo.playlist.eq(playlist),playlistVideo.status.eq(true))
+                .orderBy(playlistVideo.videoOrder.asc())
+                .fetchFirst();
+    }
 }

--- a/src/main/java/com/example/backend/playlist/repository/PlaylistRepository.java
+++ b/src/main/java/com/example/backend/playlist/repository/PlaylistRepository.java
@@ -8,6 +8,6 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface PlaylistRepository extends JpaRepository<Playlist, Long> {
+public interface PlaylistRepository extends JpaRepository<Playlist, Long>, CustomPlaylistRepository {
     List<Playlist> findAllByUser(User user);
 }

--- a/src/main/java/com/example/backend/playlist/repository/PlaylistVideoRepository.java
+++ b/src/main/java/com/example/backend/playlist/repository/PlaylistVideoRepository.java
@@ -2,11 +2,14 @@ package com.example.backend.playlist.repository;
 
 import com.example.backend.playlist.domain.Playlist;
 import com.example.backend.playlist.domain.PlaylistVideo;
+import com.example.backend.video.domain.Video;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface PlaylistVideoRepository extends JpaRepository<PlaylistVideo, Long>, CustomPlaylistVideoRepository {
+    Optional<PlaylistVideo> findByVideoAndPlaylist(Video video, Playlist playlist);
 }

--- a/src/main/java/com/example/backend/video/domain/Video.java
+++ b/src/main/java/com/example/backend/video/domain/Video.java
@@ -1,6 +1,7 @@
 package com.example.backend.video.domain;
 
 import com.example.backend.customHashtag.CustomHashtag;
+import com.example.backend.playlist.domain.PlaylistVideo;
 import com.example.backend.report.Report;
 import com.example.backend.user.domain.User;
 import lombok.Builder;
@@ -87,6 +88,9 @@ public class Video {
 
     @OneToMany(mappedBy = "video",targetEntity = Report.class)
     private List<Report> reports;
+
+    @OneToMany(mappedBy = "video", targetEntity = PlaylistVideo.class)
+    private List<PlaylistVideo> playlistVideos;
 
     @Builder
     public Video (String originTitle, String description, String videoUrl, Integer episodeNumber, Series series,User user, String thumbnailUrl, String uploader){

--- a/src/main/java/com/example/backend/video/service/VideoService.java
+++ b/src/main/java/com/example/backend/video/service/VideoService.java
@@ -2,6 +2,7 @@ package com.example.backend.video.service;
 
 import com.example.backend.customHashtag.CustomHashtag;
 import com.example.backend.customHashtag.CustomHashtagRepository;
+import com.example.backend.playlist.PlaylistService;
 import com.example.backend.user.domain.User;
 import com.example.backend.video.domain.*;
 import com.example.backend.video.dto.*;
@@ -32,6 +33,7 @@ public class VideoService {
     private final VideoHashtagRepository videoTagRepository;
     private final CustomHashtagRepository customHashtagRepository;
     private final VideoCommentService videoCommentService;
+    private final PlaylistService playlistService;
 
     public void saveVideo(VideoDto videoDto, User user){
         //플레이리스트에 영상 저장하는 부분 추가
@@ -209,6 +211,8 @@ public class VideoService {
     public void deleteVideo(Video video){
         video.setStatus(false);
         videoRepository.save(video);
+        video.getPlaylistVideos()
+                .forEach(pv->playlistService.deleteVideoInPlaylist(video,pv.getPlaylist().getId()));
     }
 
     public List<InnerInfoResponse> findSeriesNameByQuery(String q){


### PR DESCRIPTION
제목
---
플레이리스트 API (3), 플레이리스트 속 영상 관리

작업내용
---
- [x] 기능 추가
- [x] 기능 수정
- [x] 버그 수정
- [ ] 기타 설정

수정내용
---
1. 전체 플레이리스트 조회 API 구현 - 플레이리스트 제목 검색, 영상 검색 가능
2. 플레이리스트 공개 여부 수정
3. 영상 추가 시 중복 확인, 사용자 권한 확인
4. 영상 (video) 삭제 시, 플레이리스트 속 영상도 삭제
5. playlist 테이블 saveCount 필드 추가

주의사항
---
fixes #50 
