### PR TITLE
[FEAT/ADD] 플레이리스트 API (4), 구독 엔티티 생성

### DIFF
--- a/src/main/java/com/example/backend/playlist/PlaylistController.java
+++ b/src/main/java/com/example/backend/playlist/PlaylistController.java
@@ -85,4 +85,9 @@ public class PlaylistController {
         return new ResponseEntity<>(playlistService.getAllPlaylistsResponse(pageable, title, video),HttpStatus.OK);
     }
 
+    @GetMapping("/best")
+    public ResponseEntity<List<AllPlaylistsResponse>> getBestPlaylists(){
+        return new ResponseEntity<>(playlistService.getBestPlaylistsResponse(),HttpStatus.OK);
+    }
+
 }

--- a/src/main/java/com/example/backend/playlist/PlaylistController.java
+++ b/src/main/java/com/example/backend/playlist/PlaylistController.java
@@ -56,7 +56,7 @@ public class PlaylistController {
         UserSavedPlaylist savedPlaylist = playlistService.findExistingSavedPlaylist(user, playlist);
         if(savedPlaylist!=null)
             return new ResponseEntity<>("이미 저장된 플레이리스트",HttpStatus.CONFLICT);
-        playlistService.userPlaylistSave(playlist,user);
+        playlistService.saveOthersPlaylist(playlist,user);
         return new ResponseEntity<>("플레이리스트 저장 성공",HttpStatus.CREATED);
     }
 
@@ -82,7 +82,7 @@ public class PlaylistController {
     public ResponseEntity<AllPlaylistResponseWithPageCount> getAllPlaylists(@PageableDefault(size=12, sort="id",direction = Sort.Direction.DESC) Pageable pageable,
                                                                             @RequestParam(required = false) String title,
                                                                             @RequestParam(required = false) String video){
-        return new ResponseEntity<>(playlistService.getAllPlaylists(pageable, title, video),HttpStatus.OK);
+        return new ResponseEntity<>(playlistService.getAllPlaylistsResponse(pageable, title, video),HttpStatus.OK);
     }
 
 }

--- a/src/main/java/com/example/backend/playlist/PlaylistService.java
+++ b/src/main/java/com/example/backend/playlist/PlaylistService.java
@@ -74,7 +74,7 @@ public class PlaylistService {
         return null;
     }
 
-    private List<Playlist> findAllUserPlaylist(User user){
+    private List<Playlist> findAllPlaylistByUser(User user){
         return playlistRepository.findAllByUser(user)
                 .stream()
                 .filter(Playlist::getStatus)
@@ -82,7 +82,7 @@ public class PlaylistService {
     }
 
     public List<MyPlaylistResponse> getMyPlaylist(User user){
-        return findAllUserPlaylist(user)
+        return findAllPlaylistByUser(user)
                 .stream()
                 .map(MyPlaylistResponse::fromEntity)
                 .collect(Collectors.toList());
@@ -104,13 +104,13 @@ public class PlaylistService {
         return null;
     }
 
-    public void userPlaylistSave(Playlist playlist, User user){
+    public void saveOthersPlaylist(Playlist playlist, User user){
         UserSavedPlaylist userSavedPlaylist = UserSavedPlaylist.builder()
                 .playlist(playlist)
                 .user(user)
                 .status(true)
                 .build();
-        savedPlaylistRepository.save(userSavedPlaylist);
+        savedPlaylistRepository.save(userSavedPlaylist); //saveCount 도 변경
         playlist.updateSaveCount();
     }
 
@@ -150,15 +150,15 @@ public class PlaylistService {
     }
 
 
-    public AllPlaylistResponseWithPageCount getAllPlaylists(Pageable pageable, String title, String video){
+    public AllPlaylistResponseWithPageCount getAllPlaylistsResponse(Pageable pageable, String title, String video){
         Page<AllPlaylistsResponse> pageResponses = playlistRepository.findAllPlaylistsWithPageable(pageable, title, video);
         int totalPages = this.getTotalPageCount(pageResponses.getTotalElements());
         pageResponses.stream()
-                .forEach(pr->pr.updateData(getFirstVideoThumbnail(pr.getId()),findAllVideosInPlaylist(pr.getId()).size()));
+                .forEach(pr->pr.updateData(getFirstThumbnailInPlaylist(pr.getId()),findAllVideosInPlaylist(pr.getId()).size()));
         return new AllPlaylistResponseWithPageCount(totalPages, pageResponses.getContent());
     }
 
-    private String getFirstVideoThumbnail(Long playlistId){
+    private String getFirstThumbnailInPlaylist(Long playlistId){
         Playlist playlist = this.findPlaylistEntity(playlistId);
         return pvRepository.findFirstThumbnailUrl(playlist);
     }

--- a/src/main/java/com/example/backend/playlist/PlaylistService.java
+++ b/src/main/java/com/example/backend/playlist/PlaylistService.java
@@ -178,4 +178,10 @@ public class PlaylistService {
                 .collect(Collectors.toList());
     }
 
+    public List<AllPlaylistsResponse> getBestPlaylistsResponse(){
+        List<AllPlaylistsResponse> bestPlaylists = playlistRepository.findBestPlaylists();
+        bestPlaylists.forEach(r->r.updateData(getFirstThumbnailInPlaylist(r.getId()),findAllVideosInPlaylist(r.getId()).size()));
+        return bestPlaylists;
+    }
+
 }

--- a/src/main/java/com/example/backend/playlist/controller/PlaylistCommentController.java
+++ b/src/main/java/com/example/backend/playlist/controller/PlaylistCommentController.java
@@ -1,0 +1,41 @@
+package com.example.backend.playlist.controller;
+
+import com.example.backend.playlist.domain.Playlist;
+import com.example.backend.playlist.domain.PlaylistComment;
+import com.example.backend.playlist.dto.PlaylistCommentDto;
+import com.example.backend.playlist.service.PlaylistCommentService;
+import com.example.backend.playlist.service.PlaylistService;
+import com.example.backend.user.UserService;
+import com.example.backend.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/boards/playlist")
+@RequiredArgsConstructor
+public class PlaylistCommentController {
+    private final PlaylistService playlistService;
+    private final UserService userService;
+    private final PlaylistCommentService commentService;
+
+    @PostMapping("/{playlistId}/comments")
+    public ResponseEntity<String> addCommentToPlaylist(@PathVariable Long playlistId, @RequestBody PlaylistCommentDto commentDto){
+        //principal 추가
+        Long loginId=1L;
+        User user=userService.findUserById(loginId);
+        Playlist playlist=playlistService.findPlaylistEntity(playlistId);
+        if(playlist==null){
+            return new ResponseEntity<>("존재하지 않는 플레이리스트에 대한 댓글 등록 요청", HttpStatus.NOT_FOUND);
+        }
+
+        PlaylistComment playlistComment = PlaylistComment.builder()
+                .content(commentDto.getContent()).user(user)
+                .playlist(playlist).parentId(commentDto.getParentCommentId())
+                .build();
+        commentService.savePlaylistComment(playlistComment, commentDto.getParentCommentId());
+        return new ResponseEntity<>("플레이리스트 댓글 등록 성공",HttpStatus.CREATED);
+    }
+
+}

--- a/src/main/java/com/example/backend/playlist/controller/PlaylistController.java
+++ b/src/main/java/com/example/backend/playlist/controller/PlaylistController.java
@@ -1,5 +1,6 @@
-package com.example.backend.playlist;
+package com.example.backend.playlist.controller;
 
+import com.example.backend.playlist.service.PlaylistService;
 import com.example.backend.playlist.domain.Playlist;
 import com.example.backend.playlist.domain.UserSavedPlaylist;
 import com.example.backend.playlist.dto.*;

--- a/src/main/java/com/example/backend/playlist/controller/PlaylistController.java
+++ b/src/main/java/com/example/backend/playlist/controller/PlaylistController.java
@@ -43,7 +43,7 @@ public class PlaylistController {
         return new ResponseEntity<>("영상 추가 성공",HttpStatus.CREATED);
     }
 
-    @GetMapping("/{userId}")
+    @GetMapping("/user/{userId}")
     public ResponseEntity<List<MyPlaylistResponse>> getMyPlaylists(@PathVariable Long userId){
         User user = userService.findUserById(userId);
         return new ResponseEntity<>(playlistService.getMyPlaylist(user),HttpStatus.OK);
@@ -89,6 +89,13 @@ public class PlaylistController {
     @GetMapping("/best")
     public ResponseEntity<List<AllPlaylistsResponse>> getBestPlaylists(){
         return new ResponseEntity<>(playlistService.getBestPlaylistsResponse(),HttpStatus.OK);
+    }
+
+    @GetMapping("/{playlistId}")
+    public ResponseEntity<DetailPlaylistResponse> getDetailPlaylist(@PathVariable Long playlistId){
+        Long loginId=2L;
+        Playlist playlist = playlistService.findPlaylistEntity(playlistId);
+        return new ResponseEntity<>(playlistService.getDetailVideoResponse(playlist,loginId),HttpStatus.OK);
     }
 
 }

--- a/src/main/java/com/example/backend/playlist/controller/PlaylistController.java
+++ b/src/main/java/com/example/backend/playlist/controller/PlaylistController.java
@@ -98,4 +98,18 @@ public class PlaylistController {
         return new ResponseEntity<>(playlistService.getDetailVideoResponse(playlist,loginId),HttpStatus.OK);
     }
 
+    @GetMapping("/subscribe")
+    public ResponseEntity<SubscribePlaylistResponseWithPageCount> getSubscribePlaylists(@RequestParam int page, @RequestParam String sort){
+        User user = userService.findUserById(3L);
+        return new ResponseEntity<>(playlistService.getSubscribingPlaylists(user,page, sort),HttpStatus.OK);
+    }
+
+//    @PostMapping("/subscribe/{userId}")
+//    public ResponseEntity<String> subscribe(@PathVariable Long userId){
+//        User user = userService.findUserById(3L);
+//        User target = userService.findUserById(userId);
+//        userService.saveSubscribe(user,target);
+//        return new ResponseEntity<>("success",HttpStatus.OK);
+//    }
+
 }

--- a/src/main/java/com/example/backend/playlist/domain/Playlist.java
+++ b/src/main/java/com/example/backend/playlist/domain/Playlist.java
@@ -50,6 +50,9 @@ public class Playlist {
     @OneToMany(mappedBy = "playlist")
     private List<PlaylistVideo> videos;
 
+    @OneToMany(mappedBy = "playlist", targetEntity = PlaylistComment.class)
+    private List<PlaylistComment> comments;
+
     //영상 자체는 playlistVideo 에 따로 저장
     @Builder
     public Playlist(LocalDateTime now, User user, String title, Boolean isPublic){

--- a/src/main/java/com/example/backend/playlist/domain/Playlist.java
+++ b/src/main/java/com/example/backend/playlist/domain/Playlist.java
@@ -68,5 +68,7 @@ public class Playlist {
 
     public void updateSaveCount(){this.saveCount++;}
 
+    public void updateViewCount(){this.viewCount++;}
+
 
 }

--- a/src/main/java/com/example/backend/playlist/domain/PlaylistComment.java
+++ b/src/main/java/com/example/backend/playlist/domain/PlaylistComment.java
@@ -1,0 +1,63 @@
+package com.example.backend.playlist.domain;
+
+import com.example.backend.user.domain.User;
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@Entity
+@Table
+@NoArgsConstructor
+public class PlaylistComment {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "playlist_comment_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Column
+    private Boolean isParentComment; //true 면 원댓글
+
+    @Column(nullable = false)
+    private LocalDateTime createdTime;
+
+    @Column(nullable=false, name = "comment_status")
+    private Boolean status=true;
+
+    @ManyToOne(targetEntity = PlaylistComment.class)
+    @JoinColumn(name = "parent_comment_id")
+    @JsonBackReference
+    private PlaylistComment parentComment;
+
+    @OneToMany(mappedBy = "parentComment", targetEntity = PlaylistComment.class)
+    @JsonManagedReference
+    private List<PlaylistComment> childComments=new ArrayList<>();
+
+    @ManyToOne(targetEntity = Playlist.class)
+    @JoinColumn(name = "playlist_id")
+    private Playlist playlist;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Builder
+    public PlaylistComment(String content, Long parentId,Playlist playlist, User user){
+        this.content=content;
+        this.isParentComment= parentId==0;
+        this.createdTime=LocalDateTime.now();
+        this.playlist=playlist;
+        this.user=user;
+    }
+
+}

--- a/src/main/java/com/example/backend/playlist/dto/AllPlaylistsResponse.java
+++ b/src/main/java/com/example/backend/playlist/dto/AllPlaylistsResponse.java
@@ -1,5 +1,6 @@
 package com.example.backend.playlist.dto;
 
+import com.example.backend.playlist.domain.Playlist;
 import lombok.*;
 
 @Getter
@@ -18,6 +19,14 @@ public class AllPlaylistsResponse {
     public void updateData(String thumbnailUrl, Integer videoCount){
         this.titleImageUrl=thumbnailUrl;
         this.videoCount=videoCount;
+    }
+
+    public AllPlaylistsResponse(Playlist playlist){
+        this.title=playlist.getTitle();
+        this.writerNickname=playlist.getUser().getNickname();
+        this.likeCount=playlist.getLikeCount();
+        this.saveCount=playlist.getSaveCount();
+        this.id=playlist.getId();
     }
 
 }

--- a/src/main/java/com/example/backend/playlist/dto/DetailPlaylistResponse.java
+++ b/src/main/java/com/example/backend/playlist/dto/DetailPlaylistResponse.java
@@ -1,0 +1,53 @@
+package com.example.backend.playlist.dto;
+
+import com.example.backend.playlist.domain.Playlist;
+import com.example.backend.user.domain.User;
+import com.example.backend.video.dto.PlaylistVideoResponse;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+public class DetailPlaylistResponse {
+    private Long id;
+    private String title;
+    private LocalDateTime createdTime;
+    private Integer viewCount;
+    private Integer likeCount;
+    private Long writerId;
+    private String writerNickname;
+    private Boolean isThisUserWriter;
+    private Integer commentCount;
+    private List<PlaylistVideoResponse> videos;
+    private List<PlaylistCommentsResponse> comments;
+
+
+    public static DetailPlaylistResponse fromEntity(Playlist playlist, List<PlaylistCommentsResponse> comments, List<PlaylistVideoResponse> videos, Long loginId){
+//        User 객체, 요청사용자 id 파라미터 추가 + builder 패턴에 추가
+        User playlistWriter=playlist.getUser();
+        return DetailPlaylistResponse.builder()
+                .id(playlist.getId()).title(playlist.getTitle()).commentCount(getPlaylistCommentCount(comments))
+                .createdTime(playlist.getCreatedTime()).viewCount(playlist.getViewCount()).likeCount(playlist.getLikeCount())
+                .comments(comments)
+                .writerId(playlistWriter.getUserId()).writerNickname(playlistWriter.getNickname()).isThisUserWriter(playlistWriter.getUserId().equals(loginId))
+                .videos(videos)
+                .build();
+    }
+
+    private static Integer getPlaylistCommentCount(List<PlaylistCommentsResponse> comments){
+        if(comments==null)
+            return 0;
+        int count=comments.size();
+        for(PlaylistCommentsResponse r: comments){
+            if(r.getNestedComments()==null)
+                continue;
+            count+=r.getNestedComments().size();
+        }
+        return count;
+    }
+}

--- a/src/main/java/com/example/backend/playlist/dto/PlaylistCommentDto.java
+++ b/src/main/java/com/example/backend/playlist/dto/PlaylistCommentDto.java
@@ -1,0 +1,9 @@
+package com.example.backend.playlist.dto;
+
+import lombok.Getter;
+
+@Getter
+public class PlaylistCommentDto {
+    private String content;
+    private Long parentCommentId;
+}

--- a/src/main/java/com/example/backend/playlist/dto/PlaylistCommentsResponse.java
+++ b/src/main/java/com/example/backend/playlist/dto/PlaylistCommentsResponse.java
@@ -1,0 +1,34 @@
+package com.example.backend.playlist.dto;
+
+import com.example.backend.playlist.domain.PlaylistComment;
+import com.example.backend.user.domain.User;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+public class PlaylistCommentsResponse {
+    private Long id;
+    private String content;
+    private Long writerId;
+    private String writerNickname;
+    private LocalDateTime createdTime;
+    private Boolean isThisUserWriter; //현재 사용자가 이 댓글을 작성한 사람인가?
+    private Boolean isThisBoardWriterCommentWriter; //이 댓글 작성자와 게시글 작성자가 동일 인물인가?
+    private List<PlaylistCommentsResponse> nestedComments; //이 댓글이 부모댓글 (원댓글)인 경우, 자식 댓글들이 순서대로 들어감
+
+    public static PlaylistCommentsResponse fromEntity(PlaylistComment comment, Long boardWriterId, Long loginId){
+        User user = comment.getUser();
+        return PlaylistCommentsResponse.builder()
+                .id(comment.getId()).content(comment.getContent()).createdTime(comment.getCreatedTime())
+                .writerId(user.getUserId()).writerNickname(user.getNickname())
+                .isThisUserWriter(user.getUserId().equals(loginId)).isThisBoardWriterCommentWriter(user.getUserId().equals(boardWriterId))
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/backend/playlist/dto/SubscribePlaylistResponse.java
+++ b/src/main/java/com/example/backend/playlist/dto/SubscribePlaylistResponse.java
@@ -1,0 +1,19 @@
+package com.example.backend.playlist.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class SubscribePlaylistResponse {
+    //한 user 에 대해 하나의 resposne list 존재
+    private String userNickname;
+    private List<AllPlaylistsResponse> playlistsResponses;
+
+    public SubscribePlaylistResponse(String nickname, List<AllPlaylistsResponse> boards){
+        this.userNickname=nickname;
+        this.playlistsResponses=boards;
+    }
+}

--- a/src/main/java/com/example/backend/playlist/dto/SubscribePlaylistResponseWithPageCount.java
+++ b/src/main/java/com/example/backend/playlist/dto/SubscribePlaylistResponseWithPageCount.java
@@ -1,0 +1,19 @@
+package com.example.backend.playlist.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class SubscribePlaylistResponseWithPageCount {
+    //1 페이지에 1 user- 1 playlist list 존재
+    Integer totalPageCount;
+    List<SubscribePlaylistResponse> playlistsResponses;
+
+    public SubscribePlaylistResponseWithPageCount(int count, List<SubscribePlaylistResponse> boards){
+        this.totalPageCount=count;
+        this.playlistsResponses=boards;
+    }
+}

--- a/src/main/java/com/example/backend/playlist/repository/CustomPlaylistRepository.java
+++ b/src/main/java/com/example/backend/playlist/repository/CustomPlaylistRepository.java
@@ -8,4 +8,5 @@ import java.util.List;
 
 public interface CustomPlaylistRepository {
     Page<AllPlaylistsResponse> findAllPlaylistsWithPageable(Pageable pageable, String title, String videoTitle);
+    List<AllPlaylistsResponse> findBestPlaylists();
 }

--- a/src/main/java/com/example/backend/playlist/repository/CustomPlaylistRepositoryImpl.java
+++ b/src/main/java/com/example/backend/playlist/repository/CustomPlaylistRepositoryImpl.java
@@ -44,6 +44,18 @@ public class CustomPlaylistRepositoryImpl implements CustomPlaylistRepository {
         return new PageImpl<>(results.getResults(),pageable, results.getTotal());
     }
 
+    @Override
+    public List<AllPlaylistsResponse> findBestPlaylists() {
+        return jpaQueryFactory.select(Projections.fields(AllPlaylistsResponse.class,
+                playlist.id.as("id"), playlist.title.as("title"),
+                playlist.user.nickname.as("writerNickname"), playlist.likeCount.as("likeCount"), playlist.saveCount.as("saveCount")))
+                .from(playlist)
+                .where(playlist.status.eq(true),playlist.isPublic.eq(true))
+                .orderBy(playlist.likeCount.desc(),playlist.id.desc())
+                .limit(4)
+                .fetch();
+    }
+
     private BooleanExpression containsTitle(String title){
         if(title==null||title.isEmpty())
             return null;

--- a/src/main/java/com/example/backend/playlist/repository/PlaylistCommentRepository.java
+++ b/src/main/java/com/example/backend/playlist/repository/PlaylistCommentRepository.java
@@ -1,0 +1,9 @@
+package com.example.backend.playlist.repository;
+
+import com.example.backend.playlist.domain.PlaylistComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PlaylistCommentRepository extends JpaRepository<PlaylistComment, Long> {
+}

--- a/src/main/java/com/example/backend/playlist/service/PlaylistCommentService.java
+++ b/src/main/java/com/example/backend/playlist/service/PlaylistCommentService.java
@@ -1,0 +1,30 @@
+package com.example.backend.playlist.service;
+
+import com.example.backend.playlist.domain.PlaylistComment;
+import com.example.backend.playlist.repository.PlaylistCommentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class PlaylistCommentService {
+    private final PlaylistCommentRepository commentRepository;
+
+    public void savePlaylistComment(PlaylistComment comment, Long parentId){
+        PlaylistComment parentComment = checkParentComment(parentId);
+        if(parentComment!=null)
+            comment.setParentComment(parentComment);
+        commentRepository.save(comment);
+    }
+
+    private PlaylistComment checkParentComment(Long parentId){
+        if(parentId.equals(0L))
+            return null;
+        Optional<PlaylistComment> comment = commentRepository.findById(parentId);
+        if(comment.isPresent()&&comment.get().getStatus())
+            return comment.get();
+        return null;
+    }
+}

--- a/src/main/java/com/example/backend/playlist/service/PlaylistCommentService.java
+++ b/src/main/java/com/example/backend/playlist/service/PlaylistCommentService.java
@@ -2,10 +2,14 @@ package com.example.backend.playlist.service;
 
 import com.example.backend.playlist.domain.PlaylistComment;
 import com.example.backend.playlist.repository.PlaylistCommentRepository;
+import com.example.backend.playlist.dto.PlaylistCommentsResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -26,5 +30,34 @@ public class PlaylistCommentService {
         if(comment.isPresent()&&comment.get().getStatus())
             return comment.get();
         return null;
+    }
+
+    public List<PlaylistCommentsResponse> getPlaylistCommentResponses(List<PlaylistComment> comments, Long loginId, Long boardWriterId){
+        return comments.stream()
+                .map(comment->toPlaylistCommentResponse(comment,boardWriterId,loginId))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+
+    }
+
+    private PlaylistCommentsResponse toPlaylistCommentResponse(PlaylistComment comment, Long boardWriterId, Long loginId){
+        PlaylistCommentsResponse response = PlaylistCommentsResponse.fromEntity(comment, boardWriterId, loginId);
+        if(!comment.getIsParentComment()){
+            response.setNestedComments(null);
+        }else{
+            List<PlaylistComment> childComments = comment.getChildComments();
+            //각 부모 댓글들의 자식 댓글들 세팅
+            List<PlaylistCommentsResponse> childResponses = childComments.stream()
+                    .filter(childComment -> childComment.getStatus().equals(true)) //자식댓글들 중, status true인 애들만 세팅
+                    .map(childComment -> PlaylistCommentsResponse.fromEntity(childComment, boardWriterId, loginId))
+                    .collect(Collectors.toList());
+            if(!comment.getStatus()){
+                if(childResponses.isEmpty())
+                    return null;
+                response.setContent("삭제된 댓글입니다");
+            }
+            response.setNestedComments(childResponses);
+        }
+        return response;
     }
 }

--- a/src/main/java/com/example/backend/playlist/service/PlaylistService.java
+++ b/src/main/java/com/example/backend/playlist/service/PlaylistService.java
@@ -74,7 +74,7 @@ public class PlaylistService {
         return null;
     }
 
-    private List<Playlist> findAllPlaylistByUser(User user){
+    public List<Playlist> findAllPlaylistByUser(User user){
         return playlistRepository.findAllByUser(user)
                 .stream()
                 .filter(Playlist::getStatus)

--- a/src/main/java/com/example/backend/playlist/service/PlaylistService.java
+++ b/src/main/java/com/example/backend/playlist/service/PlaylistService.java
@@ -1,4 +1,4 @@
-package com.example.backend.playlist;
+package com.example.backend.playlist.service;
 
 import com.example.backend.playlist.domain.Playlist;
 import com.example.backend.playlist.domain.PlaylistVideo;

--- a/src/main/java/com/example/backend/user/SubscribeRepository.java
+++ b/src/main/java/com/example/backend/user/SubscribeRepository.java
@@ -1,0 +1,13 @@
+package com.example.backend.user;
+
+import com.example.backend.user.domain.Subscribe;
+import com.example.backend.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface SubscribeRepository extends JpaRepository<Subscribe, Long> {
+    List<Subscribe> findAllByUser(User user);
+}

--- a/src/main/java/com/example/backend/user/UserService.java
+++ b/src/main/java/com/example/backend/user/UserService.java
@@ -1,6 +1,7 @@
 package com.example.backend.user;
 
 import com.example.backend.report.Report;
+import com.example.backend.user.domain.Subscribe;
 import com.example.backend.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -9,13 +10,17 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class UserService implements UserDetailsService {
     private final UserRepository userRepository;
+    private final SubscribeRepository subscribeRepository;
 
     public User findUserById(Long userId){
         Optional<User> user = userRepository.findById(userId);
@@ -36,4 +41,22 @@ public class UserService implements UserDetailsService {
         return userRepository.findByEmail(username)
                 .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
     }
+
+    public List<Subscribe> findAllSubscribingTargets(User user){
+        return subscribeRepository.findAllByUser(user)
+                .stream()
+                .filter(Subscribe::getStatus)
+                .collect(Collectors.toList());
+    }
+
+    public void saveSubscribe(User user, User target){
+        Subscribe build = Subscribe.builder()
+                .subscribeTarget(target)
+                .lastModified(LocalDateTime.now())
+                .user(user)
+                .build();
+        subscribeRepository.save(build);
+
+    }
+
 }

--- a/src/main/java/com/example/backend/user/domain/Subscribe.java
+++ b/src/main/java/com/example/backend/user/domain/Subscribe.java
@@ -1,0 +1,40 @@
+package com.example.backend.user.domain;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Data
+@Entity
+@Table
+@NoArgsConstructor
+public class Subscribe {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "subscribe_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "subscribe_target_id")
+    private User subscribeTarget;
+
+    @Column(nullable = false, name = "subscribe_status")
+    private Boolean status=true;
+
+    @Column
+    private LocalDateTime lastModified;
+
+    @Builder
+    public Subscribe(User user, User subscribeTarget, LocalDateTime lastModified){
+        this.user=user;
+        this.subscribeTarget=subscribeTarget;
+        this.lastModified=lastModified;
+    }
+}

--- a/src/main/java/com/example/backend/video/dto/InnerInfoResponse.java
+++ b/src/main/java/com/example/backend/video/dto/InnerInfoResponse.java
@@ -1,5 +1,6 @@
 package com.example.backend.video.dto;
 
+import com.example.backend.playlist.domain.Playlist;
 import com.example.backend.video.domain.Hashtag;
 import com.example.backend.video.domain.Series;
 import lombok.Builder;
@@ -20,5 +21,10 @@ public class InnerInfoResponse {
     public InnerInfoResponse(Hashtag hashtag){
         this.id=hashtag.getId();
         this.name=hashtag.getHashtagName();
+    }
+
+    public InnerInfoResponse(Playlist playlist){
+        this.id=playlist.getId();
+        this.name=playlist.getTitle();
     }
 }

--- a/src/main/java/com/example/backend/video/dto/PlaylistVideoResponse.java
+++ b/src/main/java/com/example/backend/video/dto/PlaylistVideoResponse.java
@@ -1,0 +1,25 @@
+package com.example.backend.video.dto;
+
+import com.example.backend.video.domain.Video;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PlaylistVideoResponse {
+    private Long id;
+    private String title;
+    private String videoUploader;
+    private String thumbnailUrl;
+    private String runtime;
+
+    public static PlaylistVideoResponse fromEntity(Video video){
+        return PlaylistVideoResponse.builder()
+                .id(video.getId())
+                .title(video.getOriginVideoTitle())
+                .videoUploader(video.getVideoUploader())
+                .thumbnailUrl(video.getThumbnailUrl())
+                .runtime(video.getRuntimeHour()+":"+video.getRuntimeMin()+":"+video.getRuntimeSec())
+                .build();
+    }
+}

--- a/src/main/java/com/example/backend/video/service/VideoService.java
+++ b/src/main/java/com/example/backend/video/service/VideoService.java
@@ -37,6 +37,7 @@ public class VideoService {
     public void saveVideo(VideoDto videoDto, User user){
         //플레이리스트에 영상 저장하는 부분 추가
         Series series=getSeries(videoDto.getSeries());
+        List<Long> playlists=videoDto.getPlaylists();
         Video video=Video.builder()
                 .videoUrl(videoDto.getUrl()).description(videoDto.getDescription())
                 .originTitle(videoDto.getTitle()).series(series)
@@ -53,8 +54,15 @@ public class VideoService {
         if(videoDto.getKeywords()!=null){
             saveVideoKeywords(videoDto.getKeywords(),video);
         }
-        videoRepository.save(video);
+        Video savedVideo = videoRepository.save(video);
+        if(playlists!=null&&!playlists.isEmpty()){
+            playlists.stream()
+                    .map(playlistService::findPlaylistEntity)
+                    .forEach(p->playlistService.addVideoToPlaylist(savedVideo.getId(),p));
+
+        }
     }
+
 
     private List<Hashtag> getHashtagsByIds(List<Long> ids){
         if(ids==null){
@@ -140,7 +148,10 @@ public class VideoService {
     }
 
     private List<InnerInfoResponse> findAllPlayListsOfUser(User user){
-        return new ArrayList<>();
+        return playlistService.findAllPlaylistByUser(user)
+                .stream()
+                .map(InnerInfoResponse::new)
+                .collect(Collectors.toList());
     }
 
     public VideoUploadInfoResponse getPreInfoForVideoUpload(User user){

--- a/src/main/java/com/example/backend/video/service/VideoService.java
+++ b/src/main/java/com/example/backend/video/service/VideoService.java
@@ -2,12 +2,11 @@ package com.example.backend.video.service;
 
 import com.example.backend.customHashtag.CustomHashtag;
 import com.example.backend.customHashtag.CustomHashtagRepository;
-import com.example.backend.playlist.PlaylistService;
+import com.example.backend.playlist.service.PlaylistService;
 import com.example.backend.user.domain.User;
 import com.example.backend.video.domain.*;
 import com.example.backend.video.dto.*;
 import com.example.backend.video.repository.*;
-import com.example.backend.video.service.VideoCommentService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;


### PR DESCRIPTION
제목
---
플레이리스트 API (4), 구독 엔티티 생성

작업내용
---
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 버그 수정
- [ ] 기타 설정

수정내용
---
1. 플레이리스트 댓글 추가 API 구현
2. 상세 플레이리스트 조회 API 구현
3. 베스트 플레이리스트 조회 API 구현
4. 구독자 엔티티 생성
5. 구독하는 사용자 플레이리스트 조회 API 구현

주의사항
---
구독자 엔티티: 구독 등록 및 취소 기능은 구현안함