### PR TITLE
[마이페이지] 좋아요 한 글, 작성한 글 조회 API 구현

### DIFF
--- a/src/main/java/com/example/backend/community/repository/CommunityBoardRepository.java
+++ b/src/main/java/com/example/backend/community/repository/CommunityBoardRepository.java
@@ -1,6 +1,7 @@
 package com.example.backend.community.repository;
 
 import com.example.backend.community.domain.CommunityBoard;
+import com.example.backend.user.domain.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,4 +12,5 @@ import java.util.List;
 @Repository
 public interface CommunityBoardRepository extends JpaRepository<CommunityBoard,Long>,CustomCommunityRepository {
     Page<CommunityBoard> findAll(Pageable pageable);
+    List<CommunityBoard> findAllByUserOrderByCreatedTimeDesc(User user);
 }

--- a/src/main/java/com/example/backend/image/repository/ImageBoardRepository.java
+++ b/src/main/java/com/example/backend/image/repository/ImageBoardRepository.java
@@ -1,6 +1,8 @@
 package com.example.backend.image.repository;
 
 import com.example.backend.image.domain.ImageBoard;
+import com.example.backend.user.domain.User;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,4 +11,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ImageBoardRepository extends JpaRepository<ImageBoard,Long>, CustomImageRepository {
     Page<ImageBoard> findAll(Pageable pageable);
+    List<ImageBoard> findAllByUserOrderByCreatedTimeDesc(User user);
 }

--- a/src/main/java/com/example/backend/like/LikeRepository.java
+++ b/src/main/java/com/example/backend/like/LikeRepository.java
@@ -19,4 +19,5 @@ public interface LikeRepository extends JpaRepository<Like,Long> {
     List<Like> findAllByImageBoard(ImageBoard imageBoard);
     Like findByUserAndVideo(User user, Video video);
     Optional<Like> findByUserAndPlaylist(User user, Playlist playlist);
+    List<Like> findAllByUser(User user); // 사용자가 좋아요한 모든 데이터 조회
 }

--- a/src/main/java/com/example/backend/myPage/MyPageController.java
+++ b/src/main/java/com/example/backend/myPage/MyPageController.java
@@ -2,6 +2,7 @@ package com.example.backend.myPage;
 
 import com.example.backend.blackList.domain.BlackList;
 import com.example.backend.blackList.service.BlackListService;
+import com.example.backend.myPage.dto.LikeDataDto;
 import com.example.backend.myPage.dto.UserInfoDto;
 import com.example.backend.user.domain.User;
 import com.example.backend.user.service.UserService;
@@ -29,9 +30,9 @@ public class MyPageController {
 
     /**
      * 로그아웃
-     * */
+     */
     @PatchMapping("/edit")
-    public ResponseEntity<String> logout(HttpServletRequest request){
+    public ResponseEntity<String> logout(HttpServletRequest request) {
         String accessToken = jwtAuthenticationProvider.resolveToken(request);   // API를 요청한 토큰(Access Token) 가져오기
         BlackList blackList = new BlackList();
         blackList.setToken(accessToken);
@@ -46,5 +47,14 @@ public class MyPageController {
             return new ResponseEntity<>(null, HttpStatus.NOT_FOUND);
         }
         return new ResponseEntity<>(myPageService.findUserBasicInformation(user), HttpStatus.OK);
+    }
+
+    @GetMapping("/likes")
+    public ResponseEntity<LikeDataDto> getMyPageLikeData(@PathVariable Long userId) {
+        User user = userService.findUserById(userId);
+        if (user == null) {
+            return new ResponseEntity<>(null, HttpStatus.NOT_FOUND);
+        }
+        return new ResponseEntity<>(myPageService.getAllLikedData(user), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/backend/myPage/MyPageController.java
+++ b/src/main/java/com/example/backend/myPage/MyPageController.java
@@ -2,18 +2,20 @@ package com.example.backend.myPage;
 
 import com.example.backend.blackList.domain.BlackList;
 import com.example.backend.blackList.service.BlackListService;
-import com.example.backend.main.dto.MainCommunityResponse;
+import com.example.backend.myPage.dto.UserInfoDto;
+import com.example.backend.user.domain.User;
+import com.example.backend.user.service.UserService;
 import com.example.backend.utils.JwtAuthenticationProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.servlet.http.HttpServletRequest;
-import java.util.List;
 
 @RestController
 @RequestMapping("/user/{userId}")
@@ -22,6 +24,8 @@ public class MyPageController {
 
     private final JwtAuthenticationProvider jwtAuthenticationProvider;
     private final BlackListService blackListService;
+    private final UserService userService;
+    private final MyPageService myPageService;
 
     /**
      * 로그아웃
@@ -33,5 +37,14 @@ public class MyPageController {
         blackList.setToken(accessToken);
         blackListService.saveBlackList(blackList);
         return new ResponseEntity<>("로그아웃 되었습니다.", HttpStatus.OK);
+    }
+
+    @GetMapping("/info")
+    public ResponseEntity<UserInfoDto> getHeaderUserInformation(@PathVariable Long userId) {
+        User user = userService.findUserById(userId);
+        if (user == null) {
+            return new ResponseEntity<>(null, HttpStatus.NOT_FOUND);
+        }
+        return new ResponseEntity<>(myPageService.findUserBasicInformation(user), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/backend/myPage/MyPageController.java
+++ b/src/main/java/com/example/backend/myPage/MyPageController.java
@@ -3,6 +3,7 @@ package com.example.backend.myPage;
 import com.example.backend.blackList.domain.BlackList;
 import com.example.backend.blackList.service.BlackListService;
 import com.example.backend.myPage.dto.LikeDataDto;
+import com.example.backend.myPage.dto.MyDataDto;
 import com.example.backend.myPage.dto.UserInfoDto;
 import com.example.backend.user.domain.User;
 import com.example.backend.user.service.UserService;
@@ -56,5 +57,14 @@ public class MyPageController {
             return new ResponseEntity<>(null, HttpStatus.NOT_FOUND);
         }
         return new ResponseEntity<>(myPageService.getAllLikedData(user), HttpStatus.OK);
+    }
+
+    @GetMapping("/my")
+    public ResponseEntity<MyDataDto> getMyPageUploadedDataByUser(@PathVariable Long userId) {
+        User user = userService.findUserById(userId);
+        if (user == null) {
+            return new ResponseEntity<>(null, HttpStatus.NOT_FOUND);
+        }
+        return new ResponseEntity<>(myPageService.getAllDataUploadedByUser(user), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/backend/myPage/MyPageService.java
+++ b/src/main/java/com/example/backend/myPage/MyPageService.java
@@ -1,12 +1,18 @@
 package com.example.backend.myPage;
 
+import com.example.backend.like.Like;
+import com.example.backend.like.LikeRepository;
+import com.example.backend.myPage.dto.LikeDataDto;
+import com.example.backend.myPage.dto.MyPageCommunityDto;
+import com.example.backend.myPage.dto.MyPageImageDto;
+import com.example.backend.myPage.dto.MyPageVideoDto;
 import com.example.backend.myPage.dto.UserInfoDto;
 import com.example.backend.playlist.domain.Playlist;
 import com.example.backend.playlist.service.PlaylistService;
 import com.example.backend.user.domain.Subscribe;
 import com.example.backend.user.domain.User;
 import com.example.backend.user.repository.SubscribeRepository;
-import com.example.backend.user.service.UserService;
+import com.example.backend.video.repository.VideoRepository;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -15,15 +21,22 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class MyPageService {
-    private final UserService userService;
     private final PlaylistService playlistService;
     private final SubscribeRepository subscribeRepository;
+    private final VideoRepository videoRepository;
+    private final LikeRepository likeRepository;
 
     public UserInfoDto findUserBasicInformation(User user) {
         return UserInfoDto.fromUserAndDetail(user,
                 findAllPublicPlaylistByUser(user).size(),
                 findMySubscribers(user).size(),
                 getUserReportedCount(user));
+    }
+
+    public LikeDataDto getAllLikedData(User user) {
+        List<Like> likedData = findAllLikedByUser(user);
+        return new LikeDataDto(findAllLikedVideos(likedData), findAllLikedCommunityBoards(likedData),
+                findAllLikedImages(likedData));
     }
 
     private List<Playlist> findAllPublicPlaylistByUser(User user) {
@@ -40,5 +53,33 @@ public class MyPageService {
 
     private int getUserReportedCount(User user) {
         return user.getUserReportCount();
+    }
+
+    private List<MyPageImageDto> findAllLikedImages(List<Like> likes) {
+        return likes.stream()
+                .filter(like -> like.getImageBoard() != null)
+                .map(like -> MyPageImageDto.of(like.getImageBoard()))
+                .collect(Collectors.toList());
+    }
+
+    private List<MyPageCommunityDto> findAllLikedCommunityBoards(List<Like> likes) {
+        return likes.stream()
+                .filter(like -> like.getCommunityBoard() != null)
+                .map(like -> MyPageCommunityDto.of(like.getCommunityBoard()))
+                .collect(Collectors.toList());
+    }
+
+    private List<MyPageVideoDto> findAllLikedVideos(List<Like> likes) {
+        return likes.stream()
+                .filter(like -> like.getVideo() != null)
+                .map(like -> MyPageVideoDto.of(like.getVideo()))
+                .collect(Collectors.toList());
+    }
+
+    private List<Like> findAllLikedByUser(User user) {
+        return likeRepository.findAllByUser(user)
+                .stream()
+                .filter(Like::getLikeStatus)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/example/backend/myPage/MyPageService.java
+++ b/src/main/java/com/example/backend/myPage/MyPageService.java
@@ -1,8 +1,13 @@
 package com.example.backend.myPage;
 
+import com.example.backend.community.domain.CommunityBoard;
+import com.example.backend.community.repository.CommunityBoardRepository;
+import com.example.backend.image.domain.ImageBoard;
+import com.example.backend.image.repository.ImageBoardRepository;
 import com.example.backend.like.Like;
 import com.example.backend.like.LikeRepository;
 import com.example.backend.myPage.dto.LikeDataDto;
+import com.example.backend.myPage.dto.MyDataDto;
 import com.example.backend.myPage.dto.MyPageCommunityDto;
 import com.example.backend.myPage.dto.MyPageImageDto;
 import com.example.backend.myPage.dto.MyPageVideoDto;
@@ -12,6 +17,7 @@ import com.example.backend.playlist.service.PlaylistService;
 import com.example.backend.user.domain.Subscribe;
 import com.example.backend.user.domain.User;
 import com.example.backend.user.repository.SubscribeRepository;
+import com.example.backend.video.domain.Video;
 import com.example.backend.video.repository.VideoRepository;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -25,6 +31,8 @@ public class MyPageService {
     private final SubscribeRepository subscribeRepository;
     private final VideoRepository videoRepository;
     private final LikeRepository likeRepository;
+    private final CommunityBoardRepository communityBoardRepository;
+    private final ImageBoardRepository imageBoardRepository;
 
     public UserInfoDto findUserBasicInformation(User user) {
         return UserInfoDto.fromUserAndDetail(user,
@@ -37,6 +45,34 @@ public class MyPageService {
         List<Like> likedData = findAllLikedByUser(user);
         return new LikeDataDto(findAllLikedVideos(likedData), findAllLikedCommunityBoards(likedData),
                 findAllLikedImages(likedData));
+    }
+
+    public MyDataDto getAllDataUploadedByUser(User user) {
+        return new MyDataDto(findAllCommunityBoardByUser(user), findAllVideoByUser(user), findAllImageByUser(user));
+    }
+
+    private List<MyPageCommunityDto> findAllCommunityBoardByUser(User user) {
+        return communityBoardRepository.findAllByUserOrderByCreatedTimeDesc(user)
+                .stream()
+                .filter(CommunityBoard::getStatus)
+                .map(MyPageCommunityDto::of)
+                .collect(Collectors.toList());
+    }
+
+    private List<MyPageImageDto> findAllImageByUser(User user) {
+        return imageBoardRepository.findAllByUserOrderByCreatedTimeDesc(user)
+                .stream()
+                .filter(ImageBoard::getStatus)
+                .map(MyPageImageDto::of)
+                .collect(Collectors.toList());
+    }
+
+    private List<MyPageVideoDto> findAllVideoByUser(User user) {
+        return videoRepository.findAllByUserOrderByCreatedTimeDesc(user)
+                .stream()
+                .filter(Video::getStatus)
+                .map(MyPageVideoDto::of)
+                .collect(Collectors.toList());
     }
 
     private List<Playlist> findAllPublicPlaylistByUser(User user) {

--- a/src/main/java/com/example/backend/myPage/MyPageService.java
+++ b/src/main/java/com/example/backend/myPage/MyPageService.java
@@ -1,0 +1,44 @@
+package com.example.backend.myPage;
+
+import com.example.backend.myPage.dto.UserInfoDto;
+import com.example.backend.playlist.domain.Playlist;
+import com.example.backend.playlist.service.PlaylistService;
+import com.example.backend.user.domain.Subscribe;
+import com.example.backend.user.domain.User;
+import com.example.backend.user.repository.SubscribeRepository;
+import com.example.backend.user.service.UserService;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MyPageService {
+    private final UserService userService;
+    private final PlaylistService playlistService;
+    private final SubscribeRepository subscribeRepository;
+
+    public UserInfoDto findUserBasicInformation(User user) {
+        return UserInfoDto.fromUserAndDetail(user,
+                findAllPublicPlaylistByUser(user).size(),
+                findMySubscribers(user).size(),
+                getUserReportedCount(user));
+    }
+
+    private List<Playlist> findAllPublicPlaylistByUser(User user) {
+        return playlistService.findAllPublicPlaylistsByUserDesc(user);
+    }
+
+    private List<User> findMySubscribers(User user) {
+        return subscribeRepository.findAllBySubscribeTarget(user)
+                .stream()
+                .filter(Subscribe::getStatus)
+                .map(Subscribe::getUser)
+                .collect(Collectors.toList());
+    }
+
+    private int getUserReportedCount(User user) {
+        return user.getUserReportCount();
+    }
+}

--- a/src/main/java/com/example/backend/myPage/dto/LikeDataDto.java
+++ b/src/main/java/com/example/backend/myPage/dto/LikeDataDto.java
@@ -1,0 +1,17 @@
+package com.example.backend.myPage.dto;
+
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class LikeDataDto {
+    private final List<MyPageVideoDto> video;
+    private final List<MyPageCommunityDto> community;
+    private final List<MyPageImageDto> image;
+
+    public LikeDataDto(List<MyPageVideoDto> video, List<MyPageCommunityDto> community, List<MyPageImageDto> image) {
+        this.video = video;
+        this.community = community;
+        this.image = image;
+    }
+}

--- a/src/main/java/com/example/backend/myPage/dto/MyDataDto.java
+++ b/src/main/java/com/example/backend/myPage/dto/MyDataDto.java
@@ -1,0 +1,21 @@
+package com.example.backend.myPage.dto;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MyDataDto {
+    private final List<MyPageCommunityDto> communityDto;
+    private final List<MyPageVideoDto> videoDto;
+    private final List<MyPageImageDto> imageDto;
+    private final List<MyCommentDto> commentDto;
+
+    @Builder
+    public MyDataDto(List<MyPageCommunityDto> communityDto, List<MyPageVideoDto> videoDto, List<MyPageImageDto> imageDto) {
+        this.communityDto = communityDto;
+        this.videoDto = videoDto;
+        this.imageDto = imageDto;
+        this.commentDto = null;
+    }
+}

--- a/src/main/java/com/example/backend/myPage/dto/MyPageCommunityDto.java
+++ b/src/main/java/com/example/backend/myPage/dto/MyPageCommunityDto.java
@@ -1,0 +1,30 @@
+package com.example.backend.myPage.dto;
+
+import com.example.backend.community.domain.CommunityBoard;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MyPageCommunityDto {
+    private final Long id;
+    private final String title;
+    private final int likeCount;
+    private final int viewCount;
+    private final LocalDateTime createdTime;
+
+    public static MyPageCommunityDto of(CommunityBoard communityBoard) {
+        return MyPageCommunityDto.builder()
+                .communityBoard(communityBoard)
+                .build();
+    }
+
+    @Builder
+    private MyPageCommunityDto(CommunityBoard communityBoard) {
+        this.id = communityBoard.getId();
+        this.title = communityBoard.getTitle();
+        this.likeCount = communityBoard.getLikeCount();
+        this.viewCount = communityBoard.getViewCount();
+        this.createdTime = communityBoard.getCreatedTime();
+    }
+}

--- a/src/main/java/com/example/backend/myPage/dto/MyPageImageDto.java
+++ b/src/main/java/com/example/backend/myPage/dto/MyPageImageDto.java
@@ -1,0 +1,23 @@
+package com.example.backend.myPage.dto;
+
+import com.example.backend.image.domain.ImageBoard;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MyPageImageDto {
+    private final Long id;
+    private final String imageUrl;
+
+    public static MyPageImageDto of(ImageBoard imageBoard) {
+        return MyPageImageDto.builder()
+                .imageBoard(imageBoard)
+                .build();
+    }
+
+    @Builder
+    private MyPageImageDto(ImageBoard imageBoard) {
+        this.id = imageBoard.getId();
+        this.imageUrl = imageBoard.getImageUrl();
+    }
+}

--- a/src/main/java/com/example/backend/myPage/dto/MyPageVideoDto.java
+++ b/src/main/java/com/example/backend/myPage/dto/MyPageVideoDto.java
@@ -1,0 +1,30 @@
+package com.example.backend.myPage.dto;
+
+import com.example.backend.video.domain.Video;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MyPageVideoDto {
+    private final Long id;
+    private final String title;
+    private final String writerNickname;
+    private final int likeCount;
+    private final String thumbnailUrl;
+
+    public static MyPageVideoDto of(Video video) {
+        return MyPageVideoDto.builder()
+                .video(video)
+                .build();
+    }
+
+    @Builder
+    private MyPageVideoDto(Video video) {
+        this.id = video.getId();
+        this.title = video.getDescription();
+        this.writerNickname = video.getUser().getNickname();
+        this.likeCount = video.getLikeCount();
+        this.thumbnailUrl = video.getThumbnailUrl();
+
+    }
+}

--- a/src/main/java/com/example/backend/myPage/dto/UserInfoDto.java
+++ b/src/main/java/com/example/backend/myPage/dto/UserInfoDto.java
@@ -1,0 +1,36 @@
+package com.example.backend.myPage.dto;
+
+import com.example.backend.user.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserInfoDto {
+    private String nickname;
+    private String profileUrl;
+    private String description;
+    private int playlistCount;
+    private int subscribeCount;
+    private int reportCount;
+
+    public static UserInfoDto fromUserAndDetail(User user, int playlistCount, int subscribeCount, int reportCount) {
+        return UserInfoDto.builder()
+                .user(user)
+                .playlistCount(playlistCount)
+                .subscribeCount(subscribeCount)
+                .reportCount(reportCount)
+                .build();
+    }
+
+    @Builder
+    private UserInfoDto(User user, int playlistCount, int subscribeCount, int reportCount) {
+        this.nickname = user.getNickname();
+        this.profileUrl = user.getProfileUrl();
+        this.description = user.getUserDescription();
+        this.playlistCount = playlistCount;
+        this.subscribeCount = subscribeCount;
+        this.reportCount = reportCount;
+    }
+}

--- a/src/main/java/com/example/backend/user/repository/SubscribeRepository.java
+++ b/src/main/java/com/example/backend/user/repository/SubscribeRepository.java
@@ -10,4 +10,5 @@ import java.util.List;
 @Repository
 public interface SubscribeRepository extends JpaRepository<Subscribe, Long> {
     List<Subscribe> findAllByUser(User user);
+    List<Subscribe> findAllBySubscribeTarget(User user);
 }

--- a/src/main/java/com/example/backend/video/repository/VideoRepository.java
+++ b/src/main/java/com/example/backend/video/repository/VideoRepository.java
@@ -1,11 +1,14 @@
 package com.example.backend.video.repository;
 
+import com.example.backend.user.domain.User;
 import com.example.backend.video.domain.Video;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import java.util.List;
 
 @Repository
 public interface VideoRepository extends JpaRepository<Video, Long>, CustomVideoRepository {
     Video findByVideoUrlContains(@Param("url")String url);
+    List<Video> findAllByUserOrderByCreatedTimeDesc(User user);
 }


### PR DESCRIPTION
제목
---
마이페이지 - 사용자가 좋아요 한 글, 작성한 글을 조회하는 기능을 구현한다.

작업내용
---
- [X] 기능 추가
- [ ] 기능 수정
- [ ] 버그 수정
- [ ] 기타 설정

수정내용
---
1. 사용자가 좋아요 한 잡담글, 이미지, 영상 조회 API 구현
2. 마이페이지 상단 사용자 기본 프로필 정보 조회 API 구현
3. 사용자가 작성한 잡담글, 이미지, 영상 조회 API 구현

주의사항
---
- 노션 API 문서에는 각 좋아요 한 글, 작성한 글을 모두 개별적으로 조회하는 API 로 작성해놨는데 API가 너무 많아져서 우선 작성한 글 한 번에 / 좋아요 한 글을 모두 한 번에 조회하도록 구현
좋아요 한 글 조회: `/user/{userId}/likes`
작성한 글 조회: `/user/{userId}/my`
- 작성한 댓글 조회 기능 미구현: 댓글이 총 3개의 게시판에 있어서 모두 마이페이지용 댓글로 변환해야 하는데
1. 개별적으로 마이페이지에 들어갈 데이터로 바꿔주는 방법 (각 데이터 수집 -> 각각 DTO 로 변환 -> 날짜 순 정렬)
2. [엔티티 상속 사용](https://velog.io/@cham/JPA-%EC%83%81%EC%86%8D-%EA%B4%80%EA%B3%84-Mapping-%EC%A0%95%EB%A6%AC)

중 무엇이 더 좋은 방법일지 고민 중 입니다
