### PR TITLE
[FEAT] 마이페이지 - 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/example/backend/community/repository/CommunityCommentRepository.java
+++ b/src/main/java/com/example/backend/community/repository/CommunityCommentRepository.java
@@ -1,9 +1,12 @@
 package com.example.backend.community.repository;
 
 import com.example.backend.community.domain.CommunityComment;
+import com.example.backend.user.domain.User;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CommunityCommentRepository extends JpaRepository<CommunityComment, Long>,CustomCommunityCommentRepository {
+    List<CommunityComment> findAllByUser(User user);
 }

--- a/src/main/java/com/example/backend/myPage/BoardType.java
+++ b/src/main/java/com/example/backend/myPage/BoardType.java
@@ -1,0 +1,33 @@
+package com.example.backend.myPage;
+
+import java.util.Arrays;
+
+public enum BoardType {
+    COMMUNITY("community", "CommunityBoard"),
+    VIDEO("video", "Video"),
+    PLAYLIST("playlist", "Playlist");
+
+    private final String boardName;
+    private final String entityName;
+
+    BoardType(String name, String className) {
+        this.boardName = name;
+        this.entityName = className;
+    }
+
+    public static String findBoardType(Object board) {
+        return Arrays.stream(BoardType.values())
+                .filter(boardType -> board.getClass().getName().contains(boardType.getEntityName()))
+                .findAny()
+                .orElseThrow(() -> new IllegalArgumentException("보드 타입 에러"))
+                .getBoardName();
+    }
+
+    private String getBoardName() {
+        return boardName;
+    }
+
+    private String getEntityName() {
+        return entityName;
+    }
+}

--- a/src/main/java/com/example/backend/myPage/MyPageController.java
+++ b/src/main/java/com/example/backend/myPage/MyPageController.java
@@ -78,4 +78,13 @@ public class MyPageController {
         }
         return new ResponseEntity<>(myPageService.findAllPlaylistByUser(user), HttpStatus.OK);
     }
+
+    @GetMapping("/my/saved/playlist")
+    public ResponseEntity<List<MyPagePlaylistDto>> getSavedPlaylist(@PathVariable Long userId) {
+        User user = userService.findUserById(userId);
+        if (user == null) {
+            return new ResponseEntity<>(null, HttpStatus.NOT_FOUND);
+        }
+        return new ResponseEntity<>(myPageService.findAllSavedPlaylist(user), HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/example/backend/myPage/MyPageController.java
+++ b/src/main/java/com/example/backend/myPage/MyPageController.java
@@ -4,10 +4,12 @@ import com.example.backend.blackList.domain.BlackList;
 import com.example.backend.blackList.service.BlackListService;
 import com.example.backend.myPage.dto.LikeDataDto;
 import com.example.backend.myPage.dto.MyDataDto;
+import com.example.backend.myPage.dto.MyPagePlaylistDto;
 import com.example.backend.myPage.dto.UserInfoDto;
 import com.example.backend.user.domain.User;
 import com.example.backend.user.service.UserService;
 import com.example.backend.utils.JwtAuthenticationProvider;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -66,5 +68,14 @@ public class MyPageController {
             return new ResponseEntity<>(null, HttpStatus.NOT_FOUND);
         }
         return new ResponseEntity<>(myPageService.getAllDataUploadedByUser(user), HttpStatus.OK);
+    }
+
+    @GetMapping("/my/playlist")
+    public ResponseEntity<List<MyPagePlaylistDto>> getMyUploadedPlaylist(@PathVariable Long userId) {
+        User user = userService.findUserById(userId);
+        if (user == null) {
+            return new ResponseEntity<>(null, HttpStatus.NOT_FOUND);
+        }
+        return new ResponseEntity<>(myPageService.findAllPlaylistByUser(user), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/backend/myPage/MyPageController.java
+++ b/src/main/java/com/example/backend/myPage/MyPageController.java
@@ -6,6 +6,8 @@ import com.example.backend.myPage.dto.DetailPlaylistDto;
 import com.example.backend.myPage.dto.LikeDataDto;
 import com.example.backend.myPage.dto.MyDataDto;
 import com.example.backend.myPage.dto.MyPagePlaylistDto;
+import com.example.backend.myPage.dto.MySubscribeDto;
+import com.example.backend.myPage.dto.SubscribeRequest;
 import com.example.backend.myPage.dto.UserInfoDto;
 import com.example.backend.playlist.exception.PlaylistNotFoundException;
 import com.example.backend.user.domain.User;
@@ -19,6 +21,8 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -94,6 +98,26 @@ public class MyPageController {
     @GetMapping("/my/playlist/{playlistId}")
     public ResponseEntity<DetailPlaylistDto> getDetailMyPagePlaylist(@PathVariable Long playlistId) {
         return new ResponseEntity<>(myPageService.getMyPagePlaylistDetail(playlistId), HttpStatus.OK);
+    }
+
+    @GetMapping("/subscribe")
+    public ResponseEntity<MySubscribeDto> getSubscribeInformation(@PathVariable Long userId) {
+        User user = userService.findUserById(userId);
+        if (user == null) {
+            return new ResponseEntity<>(null, HttpStatus.NOT_FOUND);
+        }
+        return new ResponseEntity<>(myPageService.getMyPageSubscribeInfo(user), HttpStatus.OK);
+    }
+
+    @PostMapping("/subscribe")
+    public ResponseEntity<String> subscribeUser(@PathVariable Long userId, @RequestBody SubscribeRequest request) {
+        User user = userService.findUserById(userId);
+        User target = userService.findUserById(request.getTargetId());
+        if (user == null || target == null) {
+            return new ResponseEntity<>(null, HttpStatus.NOT_FOUND);
+        }
+        myPageService.saveSubscribe(user, target);
+        return new ResponseEntity<>("구독 정보 업데이트 성공", HttpStatus.OK);
     }
 
     @ExceptionHandler(PlaylistNotFoundException.class)

--- a/src/main/java/com/example/backend/myPage/MyPageController.java
+++ b/src/main/java/com/example/backend/myPage/MyPageController.java
@@ -2,10 +2,12 @@ package com.example.backend.myPage;
 
 import com.example.backend.blackList.domain.BlackList;
 import com.example.backend.blackList.service.BlackListService;
+import com.example.backend.myPage.dto.DetailPlaylistDto;
 import com.example.backend.myPage.dto.LikeDataDto;
 import com.example.backend.myPage.dto.MyDataDto;
 import com.example.backend.myPage.dto.MyPagePlaylistDto;
 import com.example.backend.myPage.dto.UserInfoDto;
+import com.example.backend.playlist.exception.PlaylistNotFoundException;
 import com.example.backend.user.domain.User;
 import com.example.backend.user.service.UserService;
 import com.example.backend.utils.JwtAuthenticationProvider;
@@ -13,6 +15,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -86,5 +89,15 @@ public class MyPageController {
             return new ResponseEntity<>(null, HttpStatus.NOT_FOUND);
         }
         return new ResponseEntity<>(myPageService.findAllSavedPlaylist(user), HttpStatus.OK);
+    }
+
+    @GetMapping("/my/playlist/{playlistId}")
+    public ResponseEntity<DetailPlaylistDto> getDetailMyPagePlaylist(@PathVariable Long playlistId) {
+        return new ResponseEntity<>(myPageService.getMyPagePlaylistDetail(playlistId), HttpStatus.OK);
+    }
+
+    @ExceptionHandler(PlaylistNotFoundException.class)
+    public ResponseEntity<String> handlePlaylistNotFoundException(PlaylistNotFoundException exception) {
+        return new ResponseEntity<>(exception.getMessage(), HttpStatus.NOT_FOUND);
     }
 }

--- a/src/main/java/com/example/backend/myPage/MyPageService.java
+++ b/src/main/java/com/example/backend/myPage/MyPageService.java
@@ -18,6 +18,7 @@ import com.example.backend.myPage.dto.MyPageVideoDto;
 import com.example.backend.myPage.dto.UserInfoDto;
 import com.example.backend.playlist.domain.Playlist;
 import com.example.backend.playlist.domain.PlaylistComment;
+import com.example.backend.playlist.domain.UserSavedPlaylist;
 import com.example.backend.playlist.repository.PlaylistCommentRepository;
 import com.example.backend.playlist.service.PlaylistService;
 import com.example.backend.user.domain.Subscribe;
@@ -67,7 +68,19 @@ public class MyPageService {
     public List<MyPagePlaylistDto> findAllPlaylistByUser(User user) {
         return playlistService.findAllPlaylistByUser(user)
                 .stream()
+                .sorted(Comparator.comparing(Playlist::getCreatedTime))
                 .map(playlist -> MyPagePlaylistDto.forMyPlaylist(playlist,
+                                playlistService.getFirstThumbnailInPlaylist(playlist.getId()),
+                                playlistService.findAllVideosInPlaylist(playlist.getId()).size()))
+                .collect(Collectors.toList());
+    }
+
+    public List<MyPagePlaylistDto> findAllSavedPlaylist(User user) {
+        return playlistService.findAllSavedPlaylistByUser(user)
+                .stream()
+                .map(UserSavedPlaylist::getPlaylist)
+                .sorted(Comparator.comparing(Playlist::getCreatedTime))
+                .map(playlist -> MyPagePlaylistDto.forSavedPlaylist(playlist,
                         playlistService.getFirstThumbnailInPlaylist(playlist.getId()),
                         playlistService.findAllVideosInPlaylist(playlist.getId()).size()))
                 .collect(Collectors.toList());

--- a/src/main/java/com/example/backend/myPage/MyPageService.java
+++ b/src/main/java/com/example/backend/myPage/MyPageService.java
@@ -13,6 +13,7 @@ import com.example.backend.myPage.dto.MyCommentDto;
 import com.example.backend.myPage.dto.MyDataDto;
 import com.example.backend.myPage.dto.MyPageCommunityDto;
 import com.example.backend.myPage.dto.MyPageImageDto;
+import com.example.backend.myPage.dto.MyPagePlaylistDto;
 import com.example.backend.myPage.dto.MyPageVideoDto;
 import com.example.backend.myPage.dto.UserInfoDto;
 import com.example.backend.playlist.domain.Playlist;
@@ -61,6 +62,15 @@ public class MyPageService {
 
     public MyDataDto getAllDataUploadedByUser(User user) {
         return new MyDataDto(findAllCommunityBoardByUser(user), findAllVideoByUser(user), findAllImageByUser(user), findAllCommentsByUser(user));
+    }
+
+    public List<MyPagePlaylistDto> findAllPlaylistByUser(User user) {
+        return playlistService.findAllPlaylistByUser(user)
+                .stream()
+                .map(playlist -> MyPagePlaylistDto.forMyPlaylist(playlist,
+                        playlistService.getFirstThumbnailInPlaylist(playlist.getId()),
+                        playlistService.findAllVideosInPlaylist(playlist.getId()).size()))
+                .collect(Collectors.toList());
     }
 
     private List<MyPageCommunityDto> findAllCommunityBoardByUser(User user) {

--- a/src/main/java/com/example/backend/myPage/MyPageService.java
+++ b/src/main/java/com/example/backend/myPage/MyPageService.java
@@ -8,6 +8,7 @@ import com.example.backend.image.domain.ImageBoard;
 import com.example.backend.image.repository.ImageBoardRepository;
 import com.example.backend.like.Like;
 import com.example.backend.like.LikeRepository;
+import com.example.backend.myPage.dto.DetailPlaylistDto;
 import com.example.backend.myPage.dto.LikeDataDto;
 import com.example.backend.myPage.dto.MyCommentDto;
 import com.example.backend.myPage.dto.MyDataDto;
@@ -19,6 +20,7 @@ import com.example.backend.myPage.dto.UserInfoDto;
 import com.example.backend.playlist.domain.Playlist;
 import com.example.backend.playlist.domain.PlaylistComment;
 import com.example.backend.playlist.domain.UserSavedPlaylist;
+import com.example.backend.playlist.exception.PlaylistNotFoundException;
 import com.example.backend.playlist.repository.PlaylistCommentRepository;
 import com.example.backend.playlist.service.PlaylistService;
 import com.example.backend.user.domain.Subscribe;
@@ -84,6 +86,17 @@ public class MyPageService {
                         playlistService.getFirstThumbnailInPlaylist(playlist.getId()),
                         playlistService.findAllVideosInPlaylist(playlist.getId()).size()))
                 .collect(Collectors.toList());
+    }
+
+    public DetailPlaylistDto getMyPagePlaylistDetail(Long playlistId) {
+        Playlist playlist = playlistService.findPlaylistEntity(playlistId);
+        if (playlist == null) {
+            throw new PlaylistNotFoundException();
+        }
+        return DetailPlaylistDto.builder()
+                .playlist(playlist)
+                .videos(playlistService.findAllVideosInPlaylist(playlistId))
+                .build();
     }
 
     private List<MyPageCommunityDto> findAllCommunityBoardByUser(User user) {

--- a/src/main/java/com/example/backend/myPage/dto/DetailPlaylistDto.java
+++ b/src/main/java/com/example/backend/myPage/dto/DetailPlaylistDto.java
@@ -1,0 +1,31 @@
+package com.example.backend.myPage.dto;
+
+import com.example.backend.playlist.domain.Playlist;
+import com.example.backend.playlist.domain.PlaylistVideo;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class DetailPlaylistDto {
+    private final Long id;
+    private final String title;
+    private final List<VideoResponseDto> videos;
+    private final Boolean isPublic;
+
+    @Builder
+    public DetailPlaylistDto(Playlist playlist, List<PlaylistVideo> videos) {
+        this.id = playlist.getId();
+        this.title = playlist.getTitle();
+        this.videos = mapVideoToResponse(videos);
+        this.isPublic = playlist.getIsPublic();
+    }
+
+    private List<VideoResponseDto> mapVideoToResponse(List<PlaylistVideo> videos) {
+        return videos.stream()
+                .map(PlaylistVideo::getVideo)
+                .map(VideoResponseDto::of)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/example/backend/myPage/dto/MyCommentDto.java
+++ b/src/main/java/com/example/backend/myPage/dto/MyCommentDto.java
@@ -1,0 +1,53 @@
+package com.example.backend.myPage.dto;
+
+import com.example.backend.community.domain.CommunityComment;
+import com.example.backend.myPage.BoardType;
+import com.example.backend.playlist.domain.PlaylistComment;
+import com.example.backend.video.domain.VideoComment;
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+public class MyCommentDto {
+    private final Long boardId;
+    private final String boardType;
+    private final String content;
+    private final String boardTitle;
+    private final LocalDateTime createdTime;
+
+    private MyCommentDto(Long id, String boardType, String content, String boardTitle, LocalDateTime createdTime) {
+        this.boardId = id;
+        this.boardType = boardType;
+        this.content = content;
+        this.boardTitle = boardTitle;
+        this.createdTime = createdTime;
+    }
+
+    public static MyCommentDto ofCommunityBoard(CommunityComment comment) {
+        return new MyCommentDto(comment.getCommunityBoard().getId(),
+                BoardType.findBoardType(comment.getCommunityBoard()),
+                comment.getContent(),
+                comment.getCommunityBoard().getTitle(),
+                comment.getCreatedTime());
+    }
+
+    public static MyCommentDto ofVideo(VideoComment comment) {
+        return new MyCommentDto(comment.getVideo().getId(),
+                BoardType.findBoardType(comment.getVideo()),
+                comment.getContent(),
+                comment.getVideo().getDescription(),
+                comment.getCreatedTime());
+    }
+
+    public static MyCommentDto ofPlaylist(PlaylistComment comment) {
+        return new MyCommentDto(comment.getPlaylist().getId(),
+                BoardType.findBoardType(comment.getPlaylist()),
+                comment.getContent(),
+                comment.getPlaylist().getTitle(),
+                comment.getCreatedTime());
+    }
+
+    public LocalDateTime getCreatedTime() {
+        return createdTime;
+    }
+}

--- a/src/main/java/com/example/backend/myPage/dto/MyDataDto.java
+++ b/src/main/java/com/example/backend/myPage/dto/MyDataDto.java
@@ -9,13 +9,13 @@ public class MyDataDto {
     private final List<MyPageCommunityDto> communityDto;
     private final List<MyPageVideoDto> videoDto;
     private final List<MyPageImageDto> imageDto;
-//    private final List<MyCommentDto> commentDto;
+    private final List<MyCommentDto> commentDto;
 
     @Builder
-    public MyDataDto(List<MyPageCommunityDto> communityDto, List<MyPageVideoDto> videoDto, List<MyPageImageDto> imageDto) {
+    public MyDataDto(List<MyPageCommunityDto> communityDto, List<MyPageVideoDto> videoDto, List<MyPageImageDto> imageDto, List<MyCommentDto> commentDto) {
         this.communityDto = communityDto;
         this.videoDto = videoDto;
         this.imageDto = imageDto;
-//        this.commentDto = null;
+        this.commentDto = commentDto;
     }
 }

--- a/src/main/java/com/example/backend/myPage/dto/MyPageImageDto.java
+++ b/src/main/java/com/example/backend/myPage/dto/MyPageImageDto.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 public class MyPageImageDto {
     private final Long id;
     private final String imageUrl;
+    private final String title;
 
     public static MyPageImageDto of(ImageBoard imageBoard) {
         return MyPageImageDto.builder()
@@ -19,5 +20,6 @@ public class MyPageImageDto {
     private MyPageImageDto(ImageBoard imageBoard) {
         this.id = imageBoard.getId();
         this.imageUrl = imageBoard.getImageUrl();
+        this.title = imageBoard.getImageBoardTitle();
     }
 }

--- a/src/main/java/com/example/backend/myPage/dto/MyPagePlaylistDto.java
+++ b/src/main/java/com/example/backend/myPage/dto/MyPagePlaylistDto.java
@@ -1,0 +1,45 @@
+package com.example.backend.myPage.dto;
+
+import com.example.backend.playlist.domain.Playlist;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MyPagePlaylistDto {
+    private final Long id;
+    private final String title;
+    private final String titleImageUrl;
+    private final String writerNickname;
+    private final int likeCount;
+    private final int videoCount;
+    private final Boolean isPublic;
+
+    public static MyPagePlaylistDto forMyPlaylist(Playlist playlist, String thumbnail, int videoCount) {
+        return MyPagePlaylistDto.builder()
+                .playlist(playlist)
+                .firstThumbnail(thumbnail)
+                .videoCount(videoCount)
+                .isPublic(playlist.getIsPublic())
+                .build();
+    }
+
+    public static MyPagePlaylistDto forSavedPlaylist(Playlist playlist, String thumbnail, int videoCount) {
+        return MyPagePlaylistDto.builder()
+                .playlist(playlist)
+                .firstThumbnail(thumbnail)
+                .videoCount(videoCount)
+                .isPublic(null)
+                .build();
+    }
+
+    @Builder
+    private MyPagePlaylistDto(Playlist playlist, String firstThumbnail, int videoCount, Boolean isPublic) {
+        this.id = playlist.getId();
+        this.title = playlist.getTitle();
+        this.titleImageUrl = firstThumbnail;
+        this.writerNickname = playlist.getUser().getNickname();
+        this.likeCount = playlist.getLikeCount();
+        this.videoCount = videoCount;
+        this.isPublic = isPublic;
+    }
+}

--- a/src/main/java/com/example/backend/myPage/dto/MySubscribeDto.java
+++ b/src/main/java/com/example/backend/myPage/dto/MySubscribeDto.java
@@ -1,0 +1,17 @@
+package com.example.backend.myPage.dto;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MySubscribeDto {
+    private final List<SubscribeUserDto> mySubscribe;
+    private final List<SubscribeUserDto> recommendedSubscribe;
+
+    @Builder
+    public MySubscribeDto(List<SubscribeUserDto> mySubscribe, List<SubscribeUserDto> recommendedSubscribe) {
+        this.mySubscribe = mySubscribe;
+        this.recommendedSubscribe = recommendedSubscribe;
+    }
+}

--- a/src/main/java/com/example/backend/myPage/dto/SubscribeRequest.java
+++ b/src/main/java/com/example/backend/myPage/dto/SubscribeRequest.java
@@ -1,0 +1,10 @@
+package com.example.backend.myPage.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SubscribeRequest {
+    private Long targetId;
+}

--- a/src/main/java/com/example/backend/myPage/dto/SubscribeUserDto.java
+++ b/src/main/java/com/example/backend/myPage/dto/SubscribeUserDto.java
@@ -1,0 +1,21 @@
+package com.example.backend.myPage.dto;
+
+import com.example.backend.user.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SubscribeUserDto {
+    private String nickname;
+    private String profileUrl;
+    private long subscribeCount;
+
+    public static SubscribeUserDto ofUser(User user, long count) {
+        return new SubscribeUserDto(user.getNickname(), user.getProfileUrl(), count);
+    }
+}

--- a/src/main/java/com/example/backend/myPage/dto/VideoResponseDto.java
+++ b/src/main/java/com/example/backend/myPage/dto/VideoResponseDto.java
@@ -1,0 +1,23 @@
+package com.example.backend.myPage.dto;
+
+import com.example.backend.video.domain.Video;
+import lombok.Getter;
+
+@Getter
+public class VideoResponseDto {
+    private final Long id;
+    private final String title;
+    private final String thumbnailUrl;
+    private final String videoUrl;
+
+    private VideoResponseDto(Video video) {
+        this.id = video.getId();
+        this.title = video.getOriginVideoTitle();
+        this.thumbnailUrl = video.getThumbnailUrl();
+        this.videoUrl = video.getVideoUrl();
+    }
+
+    public static VideoResponseDto of(Video video) {
+        return new VideoResponseDto(video);
+    }
+}

--- a/src/main/java/com/example/backend/playlist/exception/PlaylistNotFoundException.java
+++ b/src/main/java/com/example/backend/playlist/exception/PlaylistNotFoundException.java
@@ -1,0 +1,9 @@
+package com.example.backend.playlist.exception;
+
+public class PlaylistNotFoundException extends RuntimeException {
+    private static final String MESSAGE = "존재하지 않는 플레이리스트";
+
+    public PlaylistNotFoundException() {
+        super(MESSAGE);
+    }
+}

--- a/src/main/java/com/example/backend/playlist/repository/PlaylistCommentRepository.java
+++ b/src/main/java/com/example/backend/playlist/repository/PlaylistCommentRepository.java
@@ -1,9 +1,12 @@
 package com.example.backend.playlist.repository;
 
 import com.example.backend.playlist.domain.PlaylistComment;
+import com.example.backend.user.domain.User;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PlaylistCommentRepository extends JpaRepository<PlaylistComment, Long> {
+    List<PlaylistComment> findAllByUser(User user);
 }

--- a/src/main/java/com/example/backend/playlist/service/PlaylistService.java
+++ b/src/main/java/com/example/backend/playlist/service/PlaylistService.java
@@ -178,7 +178,7 @@ public class PlaylistService {
         return search;
     }
 
-    private String getFirstThumbnailInPlaylist(Long playlistId){
+    public String getFirstThumbnailInPlaylist(Long playlistId){
         Playlist playlist = this.findPlaylistEntity(playlistId);
         return pvRepository.findFirstThumbnailUrl(playlist);
     }
@@ -187,7 +187,7 @@ public class PlaylistService {
         return (int) (1+Math.ceil((totalPlaylistsCount-8)/(double)12));
     }
 
-    private List<PlaylistVideo> findAllVideosInPlaylist(Long playlistId){
+    public List<PlaylistVideo> findAllVideosInPlaylist(Long playlistId){
         Playlist playlist = this.findPlaylistEntity(playlistId);
         return playlist.getVideos()
                 .stream()

--- a/src/main/java/com/example/backend/playlist/service/PlaylistService.java
+++ b/src/main/java/com/example/backend/playlist/service/PlaylistService.java
@@ -116,7 +116,7 @@ public class PlaylistService {
         playlist.updateSaveCount();
     }
 
-    private List<UserSavedPlaylist> findAllSavedPlaylistByUser(User user){
+    public List<UserSavedPlaylist> findAllSavedPlaylistByUser(User user){
         return savedPlaylistRepository.findAllByUser(user)
                 .stream()
                 .filter(UserSavedPlaylist::getStatus)

--- a/src/main/java/com/example/backend/user/domain/Subscribe.java
+++ b/src/main/java/com/example/backend/user/domain/Subscribe.java
@@ -37,4 +37,9 @@ public class Subscribe {
         this.subscribeTarget=subscribeTarget;
         this.lastModified=lastModified;
     }
+
+    public Subscribe modifySubscribeStatus() {
+        this.status = !status;
+        return this;
+    }
 }

--- a/src/main/java/com/example/backend/user/repository/CustomSubscribeRepository.java
+++ b/src/main/java/com/example/backend/user/repository/CustomSubscribeRepository.java
@@ -1,0 +1,9 @@
+package com.example.backend.user.repository;
+
+import com.example.backend.myPage.dto.SubscribeUserDto;
+import com.example.backend.user.domain.User;
+import java.util.List;
+
+public interface CustomSubscribeRepository {
+    List<SubscribeUserDto> findAllNonSubscribingTargets(User user);
+}

--- a/src/main/java/com/example/backend/user/repository/CustomSubscribeRepositoryImpl.java
+++ b/src/main/java/com/example/backend/user/repository/CustomSubscribeRepositoryImpl.java
@@ -1,0 +1,34 @@
+package com.example.backend.user.repository;
+
+import static com.example.backend.user.domain.QSubscribe.subscribe;
+
+import com.example.backend.myPage.dto.SubscribeUserDto;
+import com.example.backend.user.domain.User;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CustomSubscribeRepositoryImpl implements CustomSubscribeRepository {
+    private final JPAQueryFactory jpaQueryFactory;
+    private final Long RECOMMENDATION_LIMIT = 1L;
+
+    @Override
+    public List<SubscribeUserDto> findAllNonSubscribingTargets(User user) {
+        return jpaQueryFactory.select(Projections.fields(SubscribeUserDto.class, subscribe.subscribeTarget.nickname.as("nickname"),
+                subscribe.subscribeTarget.profileUrl.as("profileUrl"),
+                subscribe.count().as("subscribeCount")))
+                .from(subscribe)
+                .where(predicateNonSubscribe(user.getUserId()))
+                .groupBy(subscribe.subscribeTarget.nickname, subscribe.subscribeTarget.profileUrl)
+                .having(subscribe.count().goe(RECOMMENDATION_LIMIT))
+                .orderBy(subscribe.count().desc())
+                .fetch();
+    }
+
+    private BooleanExpression predicateNonSubscribe(Long userId) {
+        return subscribe.status.isTrue().and(subscribe.user.userId.ne(userId)).and(subscribe.subscribeTarget.userId.ne(userId));
+    }
+}

--- a/src/main/java/com/example/backend/user/repository/SubscribeRepository.java
+++ b/src/main/java/com/example/backend/user/repository/SubscribeRepository.java
@@ -2,13 +2,15 @@ package com.example.backend.user.repository;
 
 import com.example.backend.user.domain.Subscribe;
 import com.example.backend.user.domain.User;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
-public interface SubscribeRepository extends JpaRepository<Subscribe, Long> {
+public interface SubscribeRepository extends JpaRepository<Subscribe, Long>, CustomSubscribeRepository {
     List<Subscribe> findAllByUser(User user);
     List<Subscribe> findAllBySubscribeTarget(User user);
+    Optional<Subscribe> findByUserAndSubscribeTarget(User user, User subscribeTarget);
 }

--- a/src/main/java/com/example/backend/user/service/UserService.java
+++ b/src/main/java/com/example/backend/user/service/UserService.java
@@ -11,7 +11,6 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -53,15 +52,6 @@ public class UserService implements UserDetailsService {
                 .stream()
                 .filter(Subscribe::getStatus)
                 .collect(Collectors.toList());
-    }
-
-    public void saveSubscribe(User user, User target){
-        Subscribe build = Subscribe.builder()
-                .subscribeTarget(target)
-                .lastModified(LocalDateTime.now())
-                .user(user)
-                .build();
-        subscribeRepository.save(build);
     }
 
 }

--- a/src/main/java/com/example/backend/video/repository/VideoCommentRepository.java
+++ b/src/main/java/com/example/backend/video/repository/VideoCommentRepository.java
@@ -1,9 +1,12 @@
 package com.example.backend.video.repository;
 
+import com.example.backend.user.domain.User;
 import com.example.backend.video.domain.VideoComment;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface VideoCommentRepository extends JpaRepository<VideoComment, Long> {
+    List<VideoComment> findAllByUser(User user);
 }


### PR DESCRIPTION
제목
---
사용자의 마이페이지 - 댓글 조회, 플레이리스트 조회, 구독 정보 조회 API 구현

작업내용
---
- [X] 기능 추가
- [X] 기능 수정
- [ ] 버그 수정
- [ ] 기타 설정

수정내용
---
1. 작성한 댓글 조회 API 구현 완료
2. 업로드 한 플레이리스트, 저장한 플레이리스트 조회 API 구현 완료
3. 구독 등록 및 취소 API 구현 완료 : 구독 메소드 `UserService` -> `MyPageService` 로 이동
4. 구독 정보 조회 API 구현 

주의사항
---
- 구독 정보 추천 기능은 현재 1명 이상의 구독자가 있을 경우 추천하는 것으로 설정
- 회원 정보 수정 기능 구현 예정
