### PR TITLE
[리팩터링] 로그인 된 사용자 연결,  예약 확정 기준 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,8 @@ dependencies {
 	implementation 'org.webjars:stomp-websocket:2.3.3-1'
 	implementation 'com.google.code.gson:gson:2.8.0'
 
+	// expiring map 사용
+	implementation 'net.jodah:expiringmap:0.5.10'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/backend/exceptionhandler/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/backend/exceptionhandler/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.example.backend.exceptionhandler;
 
+import com.example.backend.playlist.exception.NoSuchPlaylistException;
 import com.example.backend.user.exception.NoSuchUserException;
 import com.example.backend.user.exception.WrongAuthorizationException;
 import com.example.backend.video.exception.NoSuchCommentException;
@@ -31,6 +32,11 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(NoSuchCommentException.class)
     ResponseEntity<String> handleNoSuchCommentException(NoSuchCommentException exception) {
+        return new ResponseEntity<>(exception.getMessage(), HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(NoSuchPlaylistException.class)
+    ResponseEntity<String> handleNoSuchPlaylistException(NoSuchPlaylistException exception) {
         return new ResponseEntity<>(exception.getMessage(), HttpStatus.NOT_FOUND);
     }
 }

--- a/src/main/java/com/example/backend/exceptionhandler/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/backend/exceptionhandler/GlobalExceptionHandler.java
@@ -2,6 +2,8 @@ package com.example.backend.exceptionhandler;
 
 import com.example.backend.user.exception.NoSuchUserException;
 import com.example.backend.user.exception.WrongAuthorizationException;
+import com.example.backend.video.exception.NoSuchCommentException;
+import com.example.backend.video.exception.NoSuchVideoException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -19,6 +21,16 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(NoSuchUserException.class)
     ResponseEntity<String> handleNoSuchUserException(NoSuchUserException exception) {
+        return new ResponseEntity<>(exception.getMessage(), HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(NoSuchVideoException.class)
+    ResponseEntity<String> handleNoSuchVideoException(NoSuchVideoException exception) {
+        return new ResponseEntity<>(exception.getMessage(), HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(NoSuchCommentException.class)
+    ResponseEntity<String> handleNoSuchCommentException(NoSuchCommentException exception) {
         return new ResponseEntity<>(exception.getMessage(), HttpStatus.NOT_FOUND);
     }
 }

--- a/src/main/java/com/example/backend/main/MainController.java
+++ b/src/main/java/com/example/backend/main/MainController.java
@@ -5,9 +5,13 @@ import com.example.backend.main.dto.MainImageResponse;
 import com.example.backend.main.dto.MainUserResponse;
 import com.example.backend.main.dto.MainVideoResponse;
 import com.example.backend.playlist.dto.AllPlaylistsResponse;
+import com.example.backend.user.domain.User;
+import com.example.backend.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,6 +23,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class MainController {
     private final MainService mainService;
+    private final UserService userService;
 
     @GetMapping("/community")
     public ResponseEntity<List<MainCommunityResponse>> getMainCommunityBoards(){
@@ -42,10 +47,11 @@ public class MainController {
 
     @GetMapping("/user")
     public ResponseEntity<MainUserResponse> getMainUserInfo(){
-        Long loginId=8L;
-        return new ResponseEntity<>(mainService.getUserProfileForMain(loginId),HttpStatus.OK);
+        return new ResponseEntity<>(mainService.getUserProfileForMain(findUserByAuthentication().getUserId()),HttpStatus.OK);
     }
 
-
-
+    private User findUserByAuthentication() {
+        UserDetails principal = (UserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        return userService.findUserById(Long.parseLong(principal.getUsername()));
+    }
 }

--- a/src/main/java/com/example/backend/myPage/MyPageController.java
+++ b/src/main/java/com/example/backend/myPage/MyPageController.java
@@ -12,6 +12,7 @@ import com.example.backend.myPage.dto.UserEditInfoDto;
 import com.example.backend.myPage.dto.UserEditRequest;
 import com.example.backend.myPage.dto.UserInfoDto;
 import com.example.backend.playlist.exception.PlaylistNotFoundException;
+import com.example.backend.user.domain.UserCounter;
 import com.example.backend.user.domain.User;
 import com.example.backend.user.service.UserService;
 import com.example.backend.utils.JwtAuthenticationProvider;
@@ -44,6 +45,7 @@ public class MyPageController {
     private final BlackListService blackListService;
     private final UserService userService;
     private final MyPageService myPageService;
+    private final UserCounter userCounter;
 
     /**
      * 로그아웃
@@ -54,6 +56,7 @@ public class MyPageController {
         BlackList blackList = new BlackList();
         blackList.setToken(accessToken);
         blackListService.saveBlackList(blackList);
+        userCounter.logoutUser(accessToken);
         return new ResponseEntity<>("로그아웃 되었습니다.", HttpStatus.OK);
     }
 

--- a/src/main/java/com/example/backend/myPage/MyPageController.java
+++ b/src/main/java/com/example/backend/myPage/MyPageController.java
@@ -11,7 +11,6 @@ import com.example.backend.myPage.dto.SubscribeRequest;
 import com.example.backend.myPage.dto.UserEditInfoDto;
 import com.example.backend.myPage.dto.UserEditRequest;
 import com.example.backend.myPage.dto.UserInfoDto;
-import com.example.backend.playlist.exception.PlaylistNotFoundException;
 import com.example.backend.user.domain.UserCounter;
 import com.example.backend.user.domain.User;
 import com.example.backend.user.service.UserService;
@@ -24,7 +23,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -127,11 +125,6 @@ public class MyPageController {
     @DeleteMapping("/edit")
     public ResponseEntity<String> deleteUser(@PathVariable Long userId) {
         return new ResponseEntity<>(myPageService.deleteUser(findUserAndCheckAuthority(userId)), HttpStatus.NO_CONTENT);
-    }
-
-    @ExceptionHandler(PlaylistNotFoundException.class)
-    public ResponseEntity<String> handlePlaylistNotFoundException(PlaylistNotFoundException exception) {
-        return new ResponseEntity<>(exception.getMessage(), HttpStatus.NOT_FOUND);
     }
 
     private User findUserByAuthentication() {

--- a/src/main/java/com/example/backend/myPage/MyPageService.java
+++ b/src/main/java/com/example/backend/myPage/MyPageService.java
@@ -24,7 +24,6 @@ import com.example.backend.myPage.dto.UserInfoDto;
 import com.example.backend.playlist.domain.Playlist;
 import com.example.backend.playlist.domain.PlaylistComment;
 import com.example.backend.playlist.domain.UserSavedPlaylist;
-import com.example.backend.playlist.exception.PlaylistNotFoundException;
 import com.example.backend.playlist.repository.PlaylistCommentRepository;
 import com.example.backend.playlist.service.PlaylistService;
 import com.example.backend.s3Image.AwsS3Service;
@@ -102,12 +101,8 @@ public class MyPageService {
     }
 
     public DetailPlaylistDto getMyPagePlaylistDetail(Long playlistId) {
-        Playlist playlist = playlistService.findPlaylistEntity(playlistId);
-        if (playlist == null) {
-            throw new PlaylistNotFoundException();
-        }
         return DetailPlaylistDto.builder()
-                .playlist(playlist)
+                .playlist(playlistService.findPlaylistEntity(playlistId))
                 .videos(playlistService.findAllVideosInPlaylist(playlistId))
                 .build();
     }

--- a/src/main/java/com/example/backend/oauth/OAuthController.java
+++ b/src/main/java/com/example/backend/oauth/OAuthController.java
@@ -2,6 +2,7 @@ package com.example.backend.oauth;
 
 import com.example.backend.oauth.dto.OauthDto;
 import com.example.backend.oauth.service.OAuthService;
+import com.example.backend.user.domain.UserCounter;
 import com.example.backend.user.service.UserService;
 import com.example.backend.user.domain.User;
 import com.example.backend.utils.JwtAuthenticationProvider;
@@ -19,6 +20,7 @@ public class OAuthController {
     private final OAuthService oAuthService;
     private final JwtAuthenticationProvider jwtAuthenticationProvider;
     private final UserService userService;
+    private final UserCounter userCounter;
 
     /**
      * 카카오 callback
@@ -53,6 +55,7 @@ public class OAuthController {
             user = newUser;
         }
         String jsonWebToken = jwtAuthenticationProvider.createJWT(user.getUserId());
+        userCounter.loginNewUser(user.getUserId(), jsonWebToken);
         return new ResponseEntity<>(jsonWebToken, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/backend/playlist/controller/PlaylistCommentController.java
+++ b/src/main/java/com/example/backend/playlist/controller/PlaylistCommentController.java
@@ -1,6 +1,5 @@
 package com.example.backend.playlist.controller;
 
-import com.example.backend.playlist.domain.Playlist;
 import com.example.backend.playlist.domain.PlaylistComment;
 import com.example.backend.playlist.dto.PlaylistCommentDto;
 import com.example.backend.playlist.service.PlaylistCommentService;
@@ -12,6 +11,8 @@ import com.example.backend.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -25,46 +26,48 @@ public class PlaylistCommentController {
 
     @PostMapping("/{playlistId}/comments")
     public ResponseEntity<String> addCommentToPlaylist(@PathVariable Long playlistId, @RequestBody PlaylistCommentDto commentDto){
-        //principal 추가
-        Long loginId=1L;
-        User user=userService.findUserById(loginId);
-        Playlist playlist=playlistService.findPlaylistEntity(playlistId);
-        if(playlist==null){
-            return new ResponseEntity<>("존재하지 않는 플레이리스트에 대한 댓글 등록 요청", HttpStatus.NOT_FOUND);
-        }
-
         PlaylistComment playlistComment = PlaylistComment.builder()
-                .content(commentDto.getContent()).user(user)
-                .playlist(playlist).parentId(commentDto.getParentCommentId())
+                .content(commentDto.getContent()).user(findUserByAuthentication())
+                .playlist(playlistService.findPlaylistEntity(playlistId)).parentId(commentDto.getParentCommentId())
                 .build();
         commentService.savePlaylistComment(playlistComment, commentDto.getParentCommentId());
         return new ResponseEntity<>("플레이리스트 댓글 등록 성공",HttpStatus.CREATED);
     }
 
     @DeleteMapping("/{playlistId}/comments/{playlistCommentId}")
-    public ResponseEntity<String> deleteVideo(@PathVariable Long playlistCommentId){
+    public ResponseEntity<String> deletePlaylistComment(@PathVariable Long playlistCommentId){
         PlaylistComment playlistComment = commentService.findPlaylistCommentById(playlistCommentId);
+        findUserAndCheckAuthority(playlistComment.getUser().getUserId());
         commentService.deletePlaylistComment(playlistComment);
         return new ResponseEntity<>("플레이리스트 댓글 삭제 성공",HttpStatus.NO_CONTENT);
     }
 
     @PostMapping("/{playlistId}/comments/{playlistCommentId}/reports")
-    public ResponseEntity<String> reportVideoComment(@PathVariable Long playlistCommentId){
-        Long loginId=1L;
+    public ResponseEntity<String> reportPlaylistComment(@PathVariable Long playlistCommentId){
         PlaylistComment comment = commentService.findPlaylistCommentById(playlistCommentId);
-        User user = userService.findUserById(loginId);
+        User user = findUserByAuthentication();
         Boolean existence = reportService.checkReportExistence(user, comment);
-        if(existence)
-            return new ResponseEntity<>("해당 사용자가 이미 신고한 영상 댓글",HttpStatus.OK);
+        if(existence) {
+            return new ResponseEntity<>("해당 사용자가 이미 신고한 영상 댓글", HttpStatus.OK);
+        }
         Report report = Report.builder()
                 .user(user).playlistComment(comment).build();
         reportService.saveReport(report, comment.getUser());
-        if(comment.getReports().size()>=5){
+        if(comment.getReports().size() >= 5){
             commentService.deletePlaylistComment(comment);
             return new ResponseEntity<>("신고 5번 누적으로 삭제",HttpStatus.OK);
         }
         return new ResponseEntity<>("플레이리스트 댓글 신고 성공",HttpStatus.OK);
     }
 
+    private User findUserByAuthentication() {
+        UserDetails principal = (UserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        return userService.findUserById(Long.parseLong(principal.getUsername()));
+    }
 
+    private User findUserAndCheckAuthority(Long userId) {
+        User user = userService.findExistingUser(userId);
+        userService.checkUserAuthority(findUserByAuthentication().getUserId(), userId);
+        return user;
+    }
 }

--- a/src/main/java/com/example/backend/playlist/controller/PlaylistController.java
+++ b/src/main/java/com/example/backend/playlist/controller/PlaylistController.java
@@ -16,6 +16,8 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -30,97 +32,85 @@ public class PlaylistController {
     private final ReportService reportService;
 
     @PostMapping("")
-    public ResponseEntity<MyPlaylistResponse> createNewPlaylist(@RequestBody NewEmptyPlaylistDto playlistDto){
-        Long loginId=1L;
-        User user = userService.findUserById(loginId);
-        return new ResponseEntity<>(playlistService.saveEmptyPlaylist(playlistDto,user), HttpStatus.CREATED);
+    public ResponseEntity<MyPlaylistResponse> createNewPlaylist(@RequestBody NewEmptyPlaylistDto playlistDto) {
+        return new ResponseEntity<>(playlistService.saveEmptyPlaylist(playlistDto,findUserByAuthentication()), HttpStatus.CREATED);
     }
 
     @PostMapping("/{playlistId}")
     public ResponseEntity<String> addVideoToPlaylist(@PathVariable Long playlistId, @RequestBody AddVideoDto dto){
-        Long loginId=1L;
-        User user = userService.findUserById(loginId);
         Playlist playlist = playlistService.findPlaylistEntity(playlistId);
-        if(!playlistService.checkUserPlaylistAuthority(user,playlist))
-            return new ResponseEntity<>("권한 없음",HttpStatus.FORBIDDEN);
-        if(playlistService.checkVideoPlaylistExistence(dto.getVideoId(),playlist))
-            return new ResponseEntity<>("이미 해당 플레이리스트에 추가된 영상",HttpStatus.CONFLICT);
+        findUserAndCheckAuthority(playlist.getUser().getUserId());
+        if(playlistService.checkVideoPlaylistExistence(dto.getVideoId(),playlist)) {
+            return new ResponseEntity<>("이미 해당 플레이리스트에 추가된 영상", HttpStatus.CONFLICT);
+        }
         playlistService.addVideoToPlaylist(dto.getVideoId(),playlist);
         return new ResponseEntity<>("영상 추가 성공",HttpStatus.CREATED);
     }
 
     @GetMapping("/user/{userId}")
     public ResponseEntity<List<MyPlaylistResponse>> getMyPlaylists(@PathVariable Long userId){
-        User user = userService.findUserById(userId);
-        return new ResponseEntity<>(playlistService.getMyPlaylist(user),HttpStatus.OK);
+        return new ResponseEntity<>(playlistService.getMyPlaylist(findUserAndCheckAuthority(userId)),HttpStatus.OK);
     }
 
     @PostMapping("/saved")
     public ResponseEntity<String> saveOtherUserPlaylist(@RequestBody AddPlaylistDto dto){
-        Long loginId=1L;
-        User user = userService.findUserById(loginId);
+        User user = findUserByAuthentication();
         Playlist playlist = playlistService.findPlaylistEntity(dto.getPlaylistId());
         UserSavedPlaylist savedPlaylist = playlistService.findExistingSavedPlaylist(user, playlist);
-        if(savedPlaylist!=null)
-            return new ResponseEntity<>("이미 저장된 플레이리스트",HttpStatus.CONFLICT);
-        playlistService.saveOthersPlaylist(playlist,user);
+        if(savedPlaylist != null) {
+            return new ResponseEntity<>("이미 저장된 플레이리스트", HttpStatus.CONFLICT);
+        }
+        playlistService.saveOthersPlaylist(playlist, user);
         return new ResponseEntity<>("플레이리스트 저장 성공",HttpStatus.CREATED);
     }
 
     @GetMapping("/saved")
     public ResponseEntity<List<PlaylistTitleResponse>> getSavedPlaylists(){
-        Long loginId=1L;
-        User user = userService.findUserById(loginId);
-        return new ResponseEntity<>(playlistService.getUserSavedPlaylists(user),HttpStatus.OK);
+        return new ResponseEntity<>(playlistService.getUserSavedPlaylists(findUserByAuthentication()), HttpStatus.OK);
     }
 
     @PatchMapping("/{playlistId}")
     public ResponseEntity<String> changePlaylistPublic(@PathVariable Long playlistId){
-        Long loginId=1L;
-        User user = userService.findUserById(loginId);
         Playlist playlist = playlistService.findPlaylistEntity(playlistId);
-        if(!playlistService.checkUserPlaylistAuthority(user,playlist))
-            return new ResponseEntity<>("권한 없음",HttpStatus.FORBIDDEN);
+        findUserAndCheckAuthority(playlist.getUser().getUserId());
         Boolean changedStatus = playlistService.modifyPublicStatus(playlist);
         return new ResponseEntity<>(changedStatus?"공개":"비공개",HttpStatus.OK);
     }
 
     @GetMapping("")
     public ResponseEntity<AllPlaylistResponseWithPageCount> getAllPlaylists(@PageableDefault(size=12, sort="id",direction = Sort.Direction.DESC) Pageable pageable,
-                                                                            @RequestParam(required = false) String q, @RequestParam(required = false) String nickname){
+                                                                            @RequestParam(required = false) String q, @RequestParam(required = false) String nickname) {
         return new ResponseEntity<>(playlistService.getAllPlaylistsResponse(pageable, q, nickname),HttpStatus.OK);
     }
 
     @GetMapping("/best")
-    public ResponseEntity<List<AllPlaylistsResponse>> getBestPlaylists(){
+    public ResponseEntity<List<AllPlaylistsResponse>> getBestPlaylists() {
         return new ResponseEntity<>(playlistService.getBestPlaylistsResponse(),HttpStatus.OK);
     }
 
     @GetMapping("/{playlistId}")
-    public ResponseEntity<DetailPlaylistResponse> getDetailPlaylist(@PathVariable Long playlistId){
-        Long loginId=1L;
+    public ResponseEntity<DetailPlaylistResponse> getDetailPlaylist(@PathVariable Long playlistId) {
         Playlist playlist = playlistService.findPlaylistEntity(playlistId);
-        return new ResponseEntity<>(playlistService.getDetailVideoResponse(playlist,loginId),HttpStatus.OK);
+        return new ResponseEntity<>(playlistService.getDetailVideoResponse(playlist,
+                findUserByAuthentication().getUserId()),HttpStatus.OK);
     }
 
     @GetMapping("/subscribe")
     public ResponseEntity<SubscribePlaylistResponseWithPageCount> getSubscribePlaylists(@RequestParam int page, @RequestParam String sort){
-        User user = userService.findUserById(3L);
-        return new ResponseEntity<>(playlistService.getSubscribingPlaylists(user,page, sort),HttpStatus.OK);
+        return new ResponseEntity<>(playlistService.getSubscribingPlaylists(findUserByAuthentication(),page, sort),HttpStatus.OK);
     }
 
     @PostMapping("/{playlistId}/likes")
-    public ResponseEntity<Integer> likeOnVideo(@PathVariable Long playlistId) {
-        Long loginId = 1L;
+    public ResponseEntity<Integer> likeOnPlaylist(@PathVariable Long playlistId) {
         Playlist playlist = playlistService.findPlaylistEntity(playlistId);
-        User user = userService.findUserById(loginId);
+        User user = findUserByAuthentication();
         Like like = likeService.findExistingLike(playlist, user);
         Integer likeCount;
-        if(like==null){
+        if(like == null) {
             like=Like.builder()
                     .playlist(playlist).user(user).build();
             likeCount = playlist.updateLikeCount(1);
-        }else{
+        } else {
             Boolean likeStatus = like.modifyLikeStatus();
             likeCount = playlist.updateLikeCount(likeStatus?1:-1);
         }
@@ -130,42 +120,39 @@ public class PlaylistController {
 
     @DeleteMapping("/{playlistId}")
     public ResponseEntity<String> deleteVideo(@PathVariable Long playlistId){
-        //권한 확인
-        Long loginId=1L;
-        User user = userService.findUserById(loginId);
         Playlist playlist = playlistService.findPlaylistEntity(playlistId);
-        if(!playlistService.checkUserPlaylistAuthority(user, playlist))
-            return new ResponseEntity<>("권한 없음",HttpStatus.FORBIDDEN);
+        findUserAndCheckAuthority(playlist.getUser().getUserId());
         playlistService.deletePlaylist(playlist);
         return new ResponseEntity<>("플레이리스트 삭제 성공",HttpStatus.NO_CONTENT);
     }
 
     @PostMapping("/{playlistId}/reports")
     public ResponseEntity<String> reportVideo(@PathVariable Long playlistId){
-        Long loginId=1L;
         Playlist playlist = playlistService.findPlaylistEntity(playlistId);
-        User user = userService.findUserById(loginId);
+        User user = findUserByAuthentication();
         Boolean existence = reportService.checkReportExistence(user, playlist);
-        if(existence)
-            return new ResponseEntity<>("해당 사용자가 이미 신고한 플레이리스트",HttpStatus.OK);
+        if(existence) {
+            return new ResponseEntity<>("해당 사용자가 이미 신고한 플레이리스트", HttpStatus.OK);
+        }
         Report report = Report.builder()
                 .user(user).playlist(playlist).build();
         reportService.saveReport(report, playlist.getUser());
-        if(playlist.getReports().size()>=5){
+        if(playlist.getReports().size() >= 5){
             playlistService.deletePlaylist(playlist);
             return new ResponseEntity<>("신고 5번 누적으로 삭제",HttpStatus.OK);
         }
         return new ResponseEntity<>("플레이리스트 신고 성공",HttpStatus.OK);
     }
 
+    private User findUserByAuthentication() {
+        UserDetails principal = (UserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        return userService.findUserById(Long.parseLong(principal.getUsername()));
+    }
 
-
-//    @PostMapping("/subscribe/{userId}")
-//    public ResponseEntity<String> subscribe(@PathVariable Long userId){
-//        User user = userService.findUserById(3L);
-//        User target = userService.findUserById(userId);
-//        userService.saveSubscribe(user,target);
-//        return new ResponseEntity<>("success",HttpStatus.OK);
-//    }
+    private User findUserAndCheckAuthority(Long userId) {
+        User user = userService.findExistingUser(userId);
+        userService.checkUserAuthority(findUserByAuthentication().getUserId(), userId);
+        return user;
+    }
 
 }

--- a/src/main/java/com/example/backend/playlist/exception/NoSuchPlaylistException.java
+++ b/src/main/java/com/example/backend/playlist/exception/NoSuchPlaylistException.java
@@ -1,9 +1,9 @@
 package com.example.backend.playlist.exception;
 
-public class PlaylistNotFoundException extends RuntimeException {
+public class NoSuchPlaylistException extends RuntimeException {
     private static final String MESSAGE = "존재하지 않는 플레이리스트";
 
-    public PlaylistNotFoundException() {
+    public NoSuchPlaylistException() {
         super(MESSAGE);
     }
 }

--- a/src/main/java/com/example/backend/playlist/service/PlaylistCommentService.java
+++ b/src/main/java/com/example/backend/playlist/service/PlaylistCommentService.java
@@ -3,6 +3,7 @@ package com.example.backend.playlist.service;
 import com.example.backend.playlist.domain.PlaylistComment;
 import com.example.backend.playlist.repository.PlaylistCommentRepository;
 import com.example.backend.playlist.dto.PlaylistCommentsResponse;
+import com.example.backend.video.exception.NoSuchCommentException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -63,10 +64,10 @@ public class PlaylistCommentService {
 
     public PlaylistComment findPlaylistCommentById(Long id){
         Optional<PlaylistComment> comment = commentRepository.findById(id);
-        if(comment.isPresent()&&comment.get().getStatus()){
+        if(comment.isPresent() && comment.get().getStatus()){
             return comment.get();
         }
-        return null;
+        throw new NoSuchCommentException();
     }
 
     public void deletePlaylistComment(PlaylistComment comment){

--- a/src/main/java/com/example/backend/reservation/ReservationController.java
+++ b/src/main/java/com/example/backend/reservation/ReservationController.java
@@ -15,6 +15,8 @@ import java.time.format.DateTimeParseException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
@@ -31,8 +33,7 @@ public class ReservationController {
 
     @PostMapping("")
     public ResponseEntity<String> registerVideoReservation(@RequestBody ReservationDto reservationDto) {
-        Long loginId = 1L;
-        User user = userService.findUserById(loginId);
+        User user = findUserByAuthentication();
         Video video = videoService.findVideoEntityById(reservationDto.getVideoId());
         if (video == null) {
             return new ResponseEntity<>("잘못된 영상에 대한 예약 요청", HttpStatus.NOT_FOUND);
@@ -115,5 +116,10 @@ public class ReservationController {
         ConfirmedReservation reservation = reservationService.findConfirmById(confirmedReservationId);
         return new ResponseEntity<>(DetailReservationResponse.fromConfirm(reservation,
                 reservationService.getReservationsCount(reservation)), HttpStatus.OK);
+    }
+
+    private User findUserByAuthentication() {
+        UserDetails principal = (UserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        return userService.findUserById(Long.parseLong(principal.getUsername()));
     }
 }

--- a/src/main/java/com/example/backend/reservation/ReservationService.java
+++ b/src/main/java/com/example/backend/reservation/ReservationService.java
@@ -3,6 +3,7 @@ package com.example.backend.reservation;
 import com.example.backend.reservation.converter.TimeConverter;
 import com.example.backend.reservation.domain.ConfirmedReservation;
 import com.example.backend.reservation.domain.Reservation;
+import com.example.backend.user.domain.UserCounter;
 import com.example.backend.reservation.dto.*;
 import com.example.backend.reservation.exception.ConfirmExistException;
 import com.example.backend.reservation.exception.DuplicateReservationException;
@@ -24,7 +25,7 @@ import java.util.stream.Collectors;
 public class ReservationService {
     private final ReservationRepository reservationRepository;
     private final ConfirmedReservationRepository confirmedRepository;
-    private final long CONFIRM_CRITERIA = 2L;
+    private final UserCounter userCounter;
     private final int BEST_LIMIT = 3;
 
     public void saveReservation(ReservationDto reservationDto, User user, Video video) {
@@ -89,7 +90,7 @@ public class ReservationService {
     }
 
     private void makeNewConfirms(LocalDate date) {
-        reservationRepository.findReservationsConfirmNeeded(date, CONFIRM_CRITERIA)
+        reservationRepository.findReservationsConfirmNeeded(date, (long) Math.ceil((double) userCounter.getLoggedInUserCount() / 100 * 10))
                 .stream()
                 .filter(reservation -> !isAlreadySameConfirmedReservationExist(reservation.getVideo(), reservation.getStartTime(), reservation.getEndTime()))
                 .map(ConfirmedReservation::fromDto)

--- a/src/main/java/com/example/backend/user/domain/UserCounter.java
+++ b/src/main/java/com/example/backend/user/domain/UserCounter.java
@@ -1,0 +1,29 @@
+package com.example.backend.user.domain;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import net.jodah.expiringmap.ExpirationPolicy;
+import net.jodah.expiringmap.ExpiringMap;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserCounter {
+    private static final long TOKEN_VALID_TIME = 30 * 60 * 1000L;
+    private final Map<String, Long> loggedInUserCounter = ExpiringMap.builder()
+            .maxSize(10000)
+            .expirationPolicy(ExpirationPolicy.CREATED)
+            .expiration(TOKEN_VALID_TIME, TimeUnit.SECONDS)
+            .build();
+
+    public long getLoggedInUserCount() {
+        return loggedInUserCounter.size();
+    }
+
+    public void loginNewUser(long userId, String token) {
+        loggedInUserCounter.put(token, userId);
+    }
+
+    public void logoutUser(String token) {
+        loggedInUserCounter.remove(token);
+    }
+}

--- a/src/main/java/com/example/backend/video/dto/VideoDto.java
+++ b/src/main/java/com/example/backend/video/dto/VideoDto.java
@@ -1,5 +1,8 @@
 package com.example.backend.video.dto;
 
+import com.example.backend.user.domain.User;
+import com.example.backend.video.domain.Series;
+import com.example.backend.video.domain.Video;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -19,4 +22,17 @@ public class VideoDto {
     private List<Long> playlists;
     private String thumbnailUrl;
     private String videoUploader;
+
+    public Video toEntityWithUserAndSeries(User user, Series series) {
+        return Video.builder()
+                .videoUrl(url)
+                .description(description)
+                .originTitle(title)
+                .episodeNumber(episode)
+                .user(user)
+                .series(series)
+                .thumbnailUrl(thumbnailUrl)
+                .uploader(videoUploader)
+                .build();
+    }
 }

--- a/src/main/java/com/example/backend/video/exception/NoSuchCommentException.java
+++ b/src/main/java/com/example/backend/video/exception/NoSuchCommentException.java
@@ -1,0 +1,9 @@
+package com.example.backend.video.exception;
+
+public class NoSuchCommentException extends RuntimeException {
+    private static final String MESSAGE = "존재하지 않는 댓글입니다.";
+
+    public NoSuchCommentException() {
+        super(MESSAGE);
+    }
+}

--- a/src/main/java/com/example/backend/video/exception/NoSuchVideoException.java
+++ b/src/main/java/com/example/backend/video/exception/NoSuchVideoException.java
@@ -1,0 +1,9 @@
+package com.example.backend.video.exception;
+
+public class NoSuchVideoException extends RuntimeException {
+    private static final String MESSAGE = "잘못된 비디오에 대한 요청";
+
+    public NoSuchVideoException() {
+        super(MESSAGE);
+    }
+}

--- a/src/main/java/com/example/backend/video/service/VideoCommentService.java
+++ b/src/main/java/com/example/backend/video/service/VideoCommentService.java
@@ -2,6 +2,7 @@ package com.example.backend.video.service;
 
 import com.example.backend.video.domain.VideoComment;
 import com.example.backend.video.dto.VideoCommentsResponse;
+import com.example.backend.video.exception.NoSuchCommentException;
 import com.example.backend.video.repository.VideoCommentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -61,12 +62,12 @@ public class VideoCommentService {
         return response;
     }
 
-    public VideoComment findVideoCommentById(Long id){
+    public VideoComment findVideoCommentById(Long id) {
         Optional<VideoComment> comment = commentRepository.findById(id);
-        if(comment.isPresent()&&comment.get().getStatus()){
+        if(comment.isPresent() && comment.get().getStatus()){
             return comment.get();
         }
-        return null;
+        throw new NoSuchCommentException();
     }
 
     public void deleteVideoComment(VideoComment comment){

--- a/src/main/java/com/example/backend/video/service/VideoService.java
+++ b/src/main/java/com/example/backend/video/service/VideoService.java
@@ -6,14 +6,13 @@ import com.example.backend.playlist.service.PlaylistService;
 import com.example.backend.user.domain.User;
 import com.example.backend.video.domain.*;
 import com.example.backend.video.dto.*;
+import com.example.backend.video.exception.NoSuchVideoException;
 import com.example.backend.video.repository.*;
+import java.util.Collections;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -34,232 +33,225 @@ public class VideoService {
     private final VideoCommentService videoCommentService;
     private final PlaylistService playlistService;
 
-    public void saveVideo(VideoDto videoDto, User user){
-        //플레이리스트에 영상 저장하는 부분 추가
-        Series series=getSeries(videoDto.getSeries());
-        List<Long> playlists=videoDto.getPlaylists();
-        Video video=Video.builder()
-                .videoUrl(videoDto.getUrl()).description(videoDto.getDescription())
-                .originTitle(videoDto.getTitle()).series(series)
-                .episodeNumber(videoDto.getEpisode()).user(user)
-                .thumbnailUrl(videoDto.getThumbnailUrl())
-                .uploader(videoDto.getVideoUploader())
-                .build();
-        int[] times = toHourMinSec(video, videoDto.getRuntime());
-        video.setVideoRuntime(times);
-        List<Hashtag> hashtags = getHashtagsByIds(videoDto.getHashtags());
-        if(hashtags!=null){
-            saveVideoHashtag(video,hashtags);
-        }
-        if(videoDto.getKeywords()!=null){
-            saveVideoKeywords(videoDto.getKeywords(),video);
-        }
+    public void saveVideo(VideoDto videoDto, User user) {
+        List<Long> playlists = videoDto.getPlaylists();
+        Video video = videoDto.toEntityWithUserAndSeries(user, getSeries(videoDto.getSeries()));
+        video.setVideoRuntime(toHourMinSec(videoDto.getRuntime()));
+        saveVideoHashtag(video, getHashtagsByIds(videoDto.getHashtags()));
+        saveVideoKeywords(videoDto.getKeywords(), video);
         Video savedVideo = videoRepository.save(video);
-        if(playlists!=null&&!playlists.isEmpty()){
+
+        if (playlists != null && !playlists.isEmpty()) {
             playlists.stream()
                     .map(playlistService::findPlaylistEntity)
-                    .forEach(p->playlistService.addVideoToPlaylist(savedVideo.getId(),p));
+                    .forEach(playlist -> playlistService.addVideoToPlaylist(savedVideo.getId(), playlist));
 
         }
     }
 
 
-    private List<Hashtag> getHashtagsByIds(List<Long> ids){
-        if(ids==null){
-            return null;
+    private List<Hashtag> getHashtagsByIds(List<Long> ids) {
+        if (ids == null) {
+            return Collections.emptyList();
         }
         return ids.stream().map(id -> hashtagRepository.findById(id).get()).collect(Collectors.toList());
     }
 
-    private void saveVideoHashtag(Video video,List<Hashtag> hashtags){
-        int order=1;
-        for(Hashtag hashtag:hashtags){
+    private void saveVideoHashtag(Video video, List<Hashtag> hashtags) {
+        int order = 1;
+        for (Hashtag hashtag : hashtags) {
             VideoHashtag videoHashtag = VideoHashtag.builder().video(video).hashtag(hashtag).order(order++).build();
             videoTagRepository.save(videoHashtag);
         }
     }
 
-    private void saveVideoKeywords(List<String> keywords,Video video){
-        int order=1;
-        for(String keyword:keywords){
-            CustomHashtag videoKeyword = CustomHashtag.builder().video(video).name(keyword).order(order++).build();
-            customHashtagRepository.save(videoKeyword);
+    private void saveVideoKeywords(List<String> keywords, Video video) {
+        if (keywords == null || keywords.isEmpty()) {
+            return;
+        }
+        int order = 1;
+        for (String keyword : keywords) {
+            customHashtagRepository.save(CustomHashtag.builder().video(video).name(keyword).order(order++).build());
         }
     }
 
-    private Series getSeries(Long id){
+    private Series getSeries(Long id) {
         Optional<Series> series = seriesRepository.findById(id);
         return series.orElse(null);
     }
 
-    //넘어오는 시간 형태 11:10:1 (시간) 11:10 (분) 00:04 (초)
-    private int[] toHourMinSec(Video video, String runtime){
+    private int[] toHourMinSec(String runtime) {
         String[] strings = runtime.split(":");
-        int hour,min,sec;
-        switch (strings.length){
+        int hour, min, sec;
+        switch (strings.length) {
             case 3:
-                hour= parseInt(strings[0]);
-                min= parseInt(strings[1]);
-                sec= parseInt(strings[2]);
+                hour = parseInt(strings[0]);
+                min = parseInt(strings[1]);
+                sec = parseInt(strings[2]);
                 break;
             case 2:
-                hour=0;
-                min= parseInt(strings[0]);
-                sec= parseInt(strings[1]);
+                hour = 0;
+                min = parseInt(strings[0]);
+                sec = parseInt(strings[1]);
                 break;
             default:
-                hour=0;
-                min=0;
-                sec=0;
+                hour = 0;
+                min = 0;
+                sec = 0;
         }
         return new int[]{hour, min, sec};
     }
 
-    public String checkVideoUrlExistence(String url){
+    public String checkVideoUrlExistence(String url) {
         String videoId;
-        if(url.contains("watch?v")){
+        if (url.contains("watch?v")) {
             int index = url.indexOf("watch?v=");
-            videoId=url.substring(index + 8);
-            if(videoId.contains("&")){
+            videoId = url.substring(index + 8);
+            if (videoId.contains("&")) {
                 index = videoId.indexOf("&");
-                videoId=videoId.substring(0,index);
+                videoId = videoId.substring(0, index);
             }
-        }else{
-            int index=url.indexOf("youtu.be/");
-            videoId=url.substring(index + 9);
+        } else {
+            int index = url.indexOf("youtu.be/");
+            videoId = url.substring(index + 9);
         }
         Video video = videoRepository.findByVideoUrlContains(videoId);
-        if(video==null)
+        if (video == null) {
             return "등록 가능";
+        }
         return "등록 불가능";
     }
 
-    private List<InnerInfoResponse> findAllSeries(){
+    private List<InnerInfoResponse> findAllSeries() {
         return seriesRepository.findAll().stream()
                 .map(InnerInfoResponse::new)
                 .collect(Collectors.toList());
     }
 
-    private List<InnerInfoResponse> findAllHashtags(){
+    private List<InnerInfoResponse> findAllHashtags() {
         return hashtagRepository.findAll()
                 .stream()
                 .map(InnerInfoResponse::new)
                 .collect(Collectors.toList());
     }
 
-    private List<InnerInfoResponse> findAllPlayListsOfUser(User user){
+    private List<InnerInfoResponse> findAllPlayListsOfUser(User user) {
         return playlistService.findAllPlaylistByUser(user)
                 .stream()
                 .map(InnerInfoResponse::new)
                 .collect(Collectors.toList());
     }
 
-    public VideoUploadInfoResponse getPreInfoForVideoUpload(User user){
-        return VideoUploadInfoResponse.toInfoResponse(findAllSeries(),findAllHashtags(),findAllPlayListsOfUser(user));
+    public VideoUploadInfoResponse getPreInfoForVideoUpload(User user) {
+        return VideoUploadInfoResponse.toInfoResponse(findAllSeries(), findAllHashtags(), findAllPlayListsOfUser(user));
     }
 
-    public Video findVideoEntityById(Long id){
+    public Video findVideoEntityById(Long id) {
         Optional<Video> video = videoRepository.findById(id);
-        if(video.isPresent()&&video.get().getStatus()){
+        if (video.isPresent() && video.get().getStatus()) {
             return video.get();
         }
-        return null;
+        throw new NoSuchVideoException();
     }
 
-    private List<String> getHashtagKeywordStringInVideo(Video video){
+    private List<String> getHashtagKeywordStringInVideo(Video video) {
         List<VideoHashtag> videoHashtags = video.getVideoHashtags();
         List<CustomHashtag> customHashtags = video.getCustomHashtags();
         //두 개의 list 를 각각 string stream 으로 변경한 후, 두 stream을 하나로 합친 list를 반환
         return Stream.concat(videoHashtags.stream().map(videoHashtag -> videoHashtag.getHashtag().getHashtagName())
-                        ,customHashtags.stream().map(CustomHashtag::getCustomHashtagName))
+                        , customHashtags.stream().map(CustomHashtag::getCustomHashtagName))
                 .collect(Collectors.toList());
     }
 
-    public List<String> getHashtagsStringByVideoId(Long videoId){
+    public List<String> getHashtagsStringByVideoId(Long videoId) {
         Video video = this.findVideoEntityById(videoId);
         List<VideoHashtag> videoHashtags = video.getVideoHashtags();
-        return videoHashtags.stream().map(v->v.getHashtag().getHashtagName()).collect(Collectors.toList());
+        return videoHashtags.stream().map(v -> v.getHashtag().getHashtagName()).collect(Collectors.toList());
     }
 
-    public DetailVideoResponse getDetailVideoResponse(Video video, Long loginId){
+    public DetailVideoResponse getDetailVideoResponse(Video video, Long loginId) {
         User videoWriter = video.getUser();
-        Long videoWriterId=videoWriter.getUserId();
+        Long videoWriterId = videoWriter.getUserId();
         List<VideoComment> parentComments = video.getVideoComments()
                 .stream()
                 .filter(comment -> comment.getIsParentComment().equals(true)) //부모댓글만 넘김
                 .collect(Collectors.toList());
-        List<VideoCommentsResponse> videoCommentResponses = videoCommentService.getVideoCommentResponses(parentComments, loginId, videoWriterId);
-        return DetailVideoResponse.fromEntity(video,videoCommentResponses,loginId,getHashtagKeywordStringInVideo(video));
+        List<VideoCommentsResponse> videoCommentResponses = videoCommentService.getVideoCommentResponses(parentComments,
+                loginId, videoWriterId);
+        return DetailVideoResponse.fromEntity(video, videoCommentResponses, loginId,
+                getHashtagKeywordStringInVideo(video));
     }
 
-    public void updateVideoViewCount(Video video){
+    public void updateVideoViewCount(Video video) {
         video.updateVideoViewCount();
         videoRepository.save(video);
     }
 
-    public AllVideoResponseWithPageCount getAllVideosResponse(Pageable pageable, String tag, String nickname, String q){
-        List<String> tags=null;
-        if(tag!=null){
+    public AllVideoResponseWithPageCount getAllVideosResponse(Pageable pageable, String tag, String nickname,
+                                                              String q) {
+        List<String> tags = null;
+        if (tag != null) {
             tags = Arrays.stream(tag.split(",")).collect(Collectors.toList());
         }
-        List<String> queries=null;
-        if(q!=null){
-            queries=Arrays.stream(q.split(" ")).collect(Collectors.toList());
+        List<String> queries = null;
+        if (q != null) {
+            queries = Arrays.stream(q.split(" ")).collect(Collectors.toList());
         }
         TempVideoDto tempDto = videoRepository.findAll(pageable, tags, nickname, queries);
         List<AllVideoResponse> allVideoResponses = toAllResponse(tempDto.getVideos());
-        return new AllVideoResponseWithPageCount(allVideoResponses,getTotalPageCount(tempDto.getTotalCount()));
+        return new AllVideoResponseWithPageCount(allVideoResponses, getTotalPageCount(tempDto.getTotalCount()));
     }
 
-    public List<AllVideoResponse> getAllVideoForSearch(String q, String tag, String nickname, String sort){
-        List<String> tags=null;
-        if(tag!=null){
+    public List<AllVideoResponse> getAllVideoForSearch(String q, String tag, String nickname, String sort) {
+        List<String> tags = null;
+        if (tag != null) {
             tags = Arrays.stream(tag.split(",")).collect(Collectors.toList());
         }
-        List<String> queries=null;
-        if(q!=null){
-            queries=Arrays.stream(q.split(" ")).collect(Collectors.toList());
+        List<String> queries = null;
+        if (q != null) {
+            queries = Arrays.stream(q.split(" ")).collect(Collectors.toList());
         }
-        return toAllResponse(videoRepository.findAllForSearch(tags,nickname,queries,sort));
+        return toAllResponse(videoRepository.findAllForSearch(tags, nickname, queries, sort));
     }
 
-    private int getTotalPageCount(long pages){
+    private int getTotalPageCount(long pages) {
         System.out.println("total elements = " + pages);
-        if(pages<=4)
+        if (pages <= 4) {
             return 1;
+        }
         //total video count 를 기준으로 한 페이지는 4개 -> 다음페이지는 8개로 나뉜다는걸 생각해서 전체 페이지 수 반환
         //데이터 13개 (의도: 3페이지, 잘못된 연산: 2페이지) 넣어놓고 체크해보면 될듯
-        return (int) (1+Math.ceil((pages-4)/(double)8));
+        return (int) (1 + Math.ceil((pages - 4) / (double) 8));
     }
 
-    private List<AllVideoResponse> toAllResponse(List<Video> videos){
+    private List<AllVideoResponse> toAllResponse(List<Video> videos) {
         return videos.stream()
                 .map(AllVideoResponse::fromEntity)
                 .collect(Collectors.toList());
     }
 
-    public List<AllVideoResponse> getBestVideos(){
+    public List<AllVideoResponse> getBestVideos() {
         return toAllResponse(videoRepository.findBestVideos());
 
     }
 
-    public void deleteVideo(Video video){
+    public void deleteVideo(Video video) {
         video.setStatus(false);
         videoRepository.save(video);
         video.getPlaylistVideos()
-                .forEach(pv->playlistService.deleteVideoInPlaylist(video,pv.getPlaylist().getId()));
+                .forEach(pv -> playlistService.deleteVideoInPlaylist(video, pv.getPlaylist().getId()));
     }
 
-    public List<InnerInfoResponse> findSeriesNameByQuery(String q){
+    public List<InnerInfoResponse> findSeriesNameByQuery(String q) {
         return seriesRepository.findBySeriesNameContainsIgnoreCase(q)
                 .stream()
                 .map(InnerInfoResponse::new)
                 .collect(Collectors.toList());
     }
 
-    public List<Video> findVideoContainingTitle(String searchTitle,String order){
+    public List<Video> findVideoContainingTitle(String searchTitle, String order) {
         //order: id 라면? 최신순 / likeCount 라면? 좋아요순
-        return videoRepository.findTitleLike(searchTitle,order);
+        return videoRepository.findTitleLike(searchTitle, order);
     }
 
 }


### PR DESCRIPTION
제목
---
예약, 영상 게시판, 플레이리스트, 메인 페이지의 로그인 된 사용자 연결 및 예외 추가

작업내용
---
- [X] 기능 추가
- [X] 기능 수정
- [ ] 버그 수정
- [ ] 기타 설정

수정내용
---
1. 현재 로그인 된 사용자의 10% 로 예약 확정 기준 설정
2. 예약, 영상, 플레이리스트, 메인 페이지에 로그인 된 사용자 연결 및 삭제의 경우 권한 체크 추가
3. 존재하지 않는 게시물에 대한 예외 처리 추가

주의사항
---
- 전체적 코드 리팩터링 필요
- 구독 기능 사라지면서 또 없어지는 API가 생길 듯 합니다