### PR TITLE
상세 조회 토큰 수정

### DIFF
--- a/src/main/java/com/example/backend/main/MainService.java
+++ b/src/main/java/com/example/backend/main/MainService.java
@@ -47,8 +47,8 @@ public class MainService {
                 .map(MainVideoResponse::fromAllResponse)
                 .collect(Collectors.toList());
 
-        responses
-                .forEach(r->r.updateTags(videoService.getHashtagsStringByVideoId(r.getId())));
+        responses.forEach(video -> video.updateTags(
+                        videoService.getHashtagKeywordStringInVideo(videoService.findVideoEntityById(video.getId()))));
 
         return responses;
     }

--- a/src/main/java/com/example/backend/playlist/controller/PlaylistController.java
+++ b/src/main/java/com/example/backend/playlist/controller/PlaylistController.java
@@ -92,7 +92,7 @@ public class PlaylistController {
     public ResponseEntity<DetailPlaylistResponse> getDetailPlaylist(@PathVariable Long playlistId) {
         Playlist playlist = playlistService.findPlaylistEntity(playlistId);
         return new ResponseEntity<>(playlistService.getDetailVideoResponse(playlist,
-                findUserByAuthentication().getUserId()),HttpStatus.OK);
+                findUserOrAnonymousUser().getUserId()),HttpStatus.OK);
     }
 
     @GetMapping("/subscribe")
@@ -145,12 +145,8 @@ public class PlaylistController {
     }
 
     private User findUserByAuthentication() {
-        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        if (principal.equals("anonymousUser")) {
-            return User.createAnonymousUser();
-        }
-        UserDetails user = (UserDetails) principal;
-        return userService.findUserById(Long.parseLong(user.getUsername()));
+        UserDetails principal = (UserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        return userService.findUserById(Long.parseLong(principal.getUsername()));
     }
 
     private User findUserAndCheckAuthority(Long userId) {
@@ -159,4 +155,12 @@ public class PlaylistController {
         return user;
     }
 
+    private User findUserOrAnonymousUser() {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        if (principal.equals("anonymousUser")) {
+            return User.createAnonymousUser();
+        }
+        UserDetails user = (UserDetails) principal;
+        return userService.findUserById(Long.parseLong(user.getUsername()));
+    }
 }

--- a/src/main/java/com/example/backend/playlist/controller/PlaylistController.java
+++ b/src/main/java/com/example/backend/playlist/controller/PlaylistController.java
@@ -145,8 +145,12 @@ public class PlaylistController {
     }
 
     private User findUserByAuthentication() {
-        UserDetails principal = (UserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        return userService.findUserById(Long.parseLong(principal.getUsername()));
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        if (principal.equals("anonymousUser")) {
+            return User.createAnonymousUser();
+        }
+        UserDetails user = (UserDetails) principal;
+        return userService.findUserById(Long.parseLong(user.getUsername()));
     }
 
     private User findUserAndCheckAuthority(Long userId) {

--- a/src/main/java/com/example/backend/playlist/repository/CustomPlaylistRepository.java
+++ b/src/main/java/com/example/backend/playlist/repository/CustomPlaylistRepository.java
@@ -2,7 +2,6 @@ package com.example.backend.playlist.repository;
 
 import com.example.backend.playlist.dto.AllPlaylistsResponse;
 import com.example.backend.playlist.dto.TempPlaylistDto;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
@@ -10,5 +9,5 @@ import java.util.List;
 public interface CustomPlaylistRepository {
     TempPlaylistDto findAllPlaylistsWithPageable(Pageable pageable, List<String> queries, String nickname);
     List<AllPlaylistsResponse> findBestPlaylists();
-    List<AllPlaylistsResponse> findAllForSearch(String sort, String nickname, List<String> q);
+    List<AllPlaylistsResponse> findAllForSearch(String sort, List<String> q, String tag);
 }

--- a/src/main/java/com/example/backend/playlist/repository/CustomPlaylistRepositoryImpl.java
+++ b/src/main/java/com/example/backend/playlist/repository/CustomPlaylistRepositoryImpl.java
@@ -82,11 +82,10 @@ public class CustomPlaylistRepositoryImpl implements CustomPlaylistRepository {
     }
 
     private BooleanExpression checkQuery(List<String> queryList){
+        if (queryList.isEmpty()) {
+            return null;
+        }
         return Expressions.anyOf(queryList.stream().map(this::containsTitle).toArray(BooleanExpression[]::new));
-    }
-
-    private BooleanExpression containsTitle(String title){
-        return playlist.title.contains(title).or(playlist.videos.any().video.description.contains(title));
     }
 
     private BooleanExpression videoContainsTag(String tag) {
@@ -96,6 +95,10 @@ public class CustomPlaylistRepositoryImpl implements CustomPlaylistRepository {
         QPlaylistVideo videoInPlaylist = playlist.videos.any();
         return videoInPlaylist.video.customHashtags.any().customHashtagName.eq(tag)
                 .or(videoInPlaylist.video.videoHashtags.any().hashtag.hashtagName.eq(tag));
+    }
+
+    private BooleanExpression containsTitle(String title){
+        return playlist.title.contains(title).or(playlist.videos.any().video.description.contains(title));
     }
 
     private List<OrderSpecifier> order(Sort sort){

--- a/src/main/java/com/example/backend/playlist/repository/CustomPlaylistRepositoryImpl.java
+++ b/src/main/java/com/example/backend/playlist/repository/CustomPlaylistRepositoryImpl.java
@@ -1,20 +1,16 @@
 package com.example.backend.playlist.repository;
 
-import com.example.backend.playlist.domain.PlaylistVideo;
 import com.example.backend.playlist.domain.QPlaylistVideo;
 import com.example.backend.playlist.dto.AllPlaylistsResponse;
 import com.example.backend.playlist.dto.TempPlaylistDto;
-import com.querydsl.core.QueryResults;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
-import com.querydsl.core.types.dsl.ListPath;
+import com.querydsl.core.util.StringUtils;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
@@ -23,8 +19,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static com.example.backend.playlist.domain.QPlaylist.playlist;
-import static com.example.backend.playlist.domain.QPlaylistVideo.playlistVideo;
-import static com.example.backend.video.domain.QVideo.video;
 
 @RequiredArgsConstructor
 public class CustomPlaylistRepositoryImpl implements CustomPlaylistRepository {
@@ -42,7 +36,7 @@ public class CustomPlaylistRepositoryImpl implements CustomPlaylistRepository {
                         playlist.id.as("id"), playlist.title.as("title"),
                         playlist.user.nickname.as("writerNickname"), playlist.likeCount.as("likeCount"), playlist.saveCount.as("saveCount")))
                 .from(playlist)
-                .where(predicate(queries,nickname), playlist.status.eq(true), playlist.isPublic.eq(true))
+                .where(predicate(queries, null), playlist.status.eq(true), playlist.isPublic.eq(true))
                 .orderBy(order(pageable.getSort()).toArray(OrderSpecifier[]::new))
                 .fetch();
 
@@ -66,7 +60,7 @@ public class CustomPlaylistRepositoryImpl implements CustomPlaylistRepository {
     }
 
     @Override
-    public List<AllPlaylistsResponse> findAllForSearch(String sort, String nickname, List<String> queries) {
+    public List<AllPlaylistsResponse> findAllForSearch(String sort, List<String> queries, String tag) {
         List<OrderSpecifier> orders=new ArrayList<>();
         if(sort.contains("like")){
             orders.add(new OrderSpecifier(Order.DESC, playlist.likeCount));
@@ -77,50 +71,31 @@ public class CustomPlaylistRepositoryImpl implements CustomPlaylistRepository {
                         playlist.id.as("id"), playlist.title.as("title"),
                         playlist.user.nickname.as("writerNickname"), playlist.likeCount.as("likeCount"), playlist.saveCount.as("saveCount")))
                 .from(playlist)
-                .where(predicate(queries,nickname), playlist.status.eq(true), playlist.isPublic.eq(true))
+                .where(predicate(queries, tag), playlist.status.eq(true), playlist.isPublic.eq(true))
                 .orderBy(orders.toArray(OrderSpecifier[]::new))
                 .limit(8)
                 .fetch();
-
-
     }
 
-    private BooleanExpression predicate(List<String> queries, String nickname){
-        //해시태그에 있거나 키워드 (커스텀 해시태그) 에 있거나
-        BooleanExpression nicknameExpression=null;
-        BooleanExpression queryExpressions=null;
-        if(nickname!=null){
-            nicknameExpression = checkNickname(nickname);
-        }
-
-        if(queries!=null){
-            queryExpressions=checkQuery(queries);
-        }
-
-        return Expressions.allOf(nicknameExpression,queryExpressions);
+    private BooleanExpression predicate(List<String> queries, String tag){
+        return Expressions.allOf(checkQuery(queries), videoContainsTag(tag));
     }
 
     private BooleanExpression checkQuery(List<String> queryList){
-        if(queryList==null)
-            return null;
         return Expressions.anyOf(queryList.stream().map(this::containsTitle).toArray(BooleanExpression[]::new));
     }
 
     private BooleanExpression containsTitle(String title){
-        if(title==null||title.isEmpty())
-            return null;
-        ListPath<PlaylistVideo, QPlaylistVideo> videos = playlist.videos;
-        return playlist.title.contains(title).or(videos.any().video.description.contains(title));
+        return playlist.title.contains(title).or(playlist.videos.any().video.description.contains(title));
     }
 
-//    private BooleanExpression containsVideo(String title){
-//        if(title==null||title.isEmpty())
-//            return null;
-//        return playlist.videos.any().video.description.contains(title));
-//    }
-
-    private BooleanExpression checkNickname(String nickname){
-        return playlist.user.nickname.eq(nickname);
+    private BooleanExpression videoContainsTag(String tag) {
+        if (StringUtils.isNullOrEmpty(tag)) {
+            return null;
+        }
+        QPlaylistVideo videoInPlaylist = playlist.videos.any();
+        return videoInPlaylist.video.customHashtags.any().customHashtagName.eq(tag)
+                .or(videoInPlaylist.video.videoHashtags.any().hashtag.hashtagName.eq(tag));
     }
 
     private List<OrderSpecifier> order(Sort sort){

--- a/src/main/java/com/example/backend/playlist/service/PlaylistService.java
+++ b/src/main/java/com/example/backend/playlist/service/PlaylistService.java
@@ -163,14 +163,12 @@ public class PlaylistService {
         return new AllPlaylistResponseWithPageCount(totalPages, responses);
     }
 
-    public List<AllPlaylistsResponse> getAllPlaylistForSearch(String q, String sort, String nickname){
-        List<String> queries=null;
-        if(q!=null){
-            queries=Arrays.stream(q.split(" ")).collect(Collectors.toList());
-        }
-        List<AllPlaylistsResponse> search = playlistRepository.findAllForSearch(sort, nickname, queries);
-        search.forEach(pr->pr.updateData(getFirstThumbnailInPlaylist(pr.getId()),findAllVideosInPlaylist(pr.getId()).size()));
-        return search;
+    public List<AllPlaylistsResponse> getAllPlaylistForSearch(String q, String sort, String tag){
+        List<String> queries = Arrays.stream(q.split(" ")).collect(Collectors.toList());
+        List<AllPlaylistsResponse> searchResult = playlistRepository.findAllForSearch(sort, queries, tag);
+        searchResult.forEach(playlist -> playlist.updateData(
+                getFirstThumbnailInPlaylist(playlist.getId()), findAllVideosInPlaylist(playlist.getId()).size()));
+        return searchResult;
     }
 
     public String getFirstThumbnailInPlaylist(Long playlistId){

--- a/src/main/java/com/example/backend/search/SearchController.java
+++ b/src/main/java/com/example/backend/search/SearchController.java
@@ -1,13 +1,7 @@
 package com.example.backend.search;
 
-import com.example.backend.community.dto.AllCommunityBoardsResponse;
-import com.example.backend.main.MainService;
-import com.example.backend.main.dto.MainCommunityResponse;
-import com.example.backend.main.dto.MainImageResponse;
-import com.example.backend.main.dto.MainUserResponse;
 import com.example.backend.main.dto.MainVideoResponse;
 import com.example.backend.playlist.dto.AllPlaylistsResponse;
-import com.example.backend.search.dto.SearchVideoResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -23,31 +17,30 @@ import java.util.List;
 @RequiredArgsConstructor
 public class SearchController {
     private final SearchService searchService;
+    private final static String EMPTY = "";
 
-    @GetMapping("/community")
-    public ResponseEntity<List<AllCommunityBoardsResponse>> searchCommunityBoards(@RequestParam String sort, @RequestParam(required = false) String q){
-        return new ResponseEntity<>(searchService.getCommunityForSearch(q,sort), HttpStatus.OK);
-    }
-
-    @GetMapping("/image")
-    public ResponseEntity<List<MainImageResponse>> searchImageBoards(@RequestParam String sort, @RequestParam(required = false) String q,
-                                                                      @RequestParam(required = false) String tag){
-        return new ResponseEntity<>(searchService.getImageForSearch(q,tag,sort),HttpStatus.OK);
-    }
+//    @GetMapping("/community")
+//    public ResponseEntity<List<AllCommunityBoardsResponse>> searchCommunityBoards(@RequestParam String sort, @RequestParam(required = false) String q){
+//        return new ResponseEntity<>(searchService.getCommunityForSearch(q,sort), HttpStatus.OK);
+//    }
+//
+//    @GetMapping("/image")
+//    public ResponseEntity<List<MainImageResponse>> searchImageBoards(@RequestParam String sort, @RequestParam(required = false) String q,
+//                                                                      @RequestParam(required = false) String tag){
+//        return new ResponseEntity<>(searchService.getImageForSearch(q,tag,sort),HttpStatus.OK);
+//    }
 
     @GetMapping("/video")
-    public ResponseEntity<List<MainVideoResponse>> searchVideoBoards(@RequestParam String sort, @RequestParam(required = false) String q,
-                                                                       @RequestParam(required = false) String tag, @RequestParam(required = false) String nickname){
-        return new ResponseEntity<>(searchService.getVideoForSearch(q,tag,nickname,sort),HttpStatus.OK);
+    public ResponseEntity<List<MainVideoResponse>> searchVideoBoards(@RequestParam String sort,
+                                                                     @RequestParam(required = false, defaultValue = EMPTY) String q,
+                                                                     @RequestParam(required = false, defaultValue = EMPTY) String tag) {
+        return new ResponseEntity<>(searchService.getVideoForSearch(q,tag,sort),HttpStatus.OK);
     }
 
     @GetMapping("/playlist")
-    public ResponseEntity<List<AllPlaylistsResponse>> getMainPlaylistBoards(@RequestParam String sort, @RequestParam(required = false) String q,
-                                                                            @RequestParam(required = false) String nickname){
-        return new ResponseEntity<>(searchService.getPlaylistsForSearch(sort,q,nickname),HttpStatus.OK);
+    public ResponseEntity<List<AllPlaylistsResponse>> getMainPlaylistBoards(@RequestParam String sort,
+                                                                            @RequestParam(required = false, defaultValue = EMPTY) String q,
+                                                                            @RequestParam(required = false) String tag) {
+        return new ResponseEntity<>(searchService.getPlaylistsForSearch(sort, q, tag),HttpStatus.OK);
     }
-
-
-
-
 }

--- a/src/main/java/com/example/backend/search/SearchService.java
+++ b/src/main/java/com/example/backend/search/SearchService.java
@@ -18,41 +18,39 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 public class SearchService {
-    private final UserService userService;
     private final CommunityBoardService communityService;
     private final ImageBoardRepository imageRepository;
     private final VideoService videoService;
     private final PlaylistService playlistService;
 
-    public List<AllCommunityBoardsResponse> getCommunityForSearch(String q, String sort){
-            return communityService.getSearchedCommunityBoards(q,sort);
+    public List<AllCommunityBoardsResponse> getCommunityForSearch(String q, String sort) {
+        return communityService.getSearchedCommunityBoards(q, sort);
     }
 
-    public List<MainImageResponse> getImageForSearch(String query, String tag, String sort){
+    public List<MainImageResponse> getImageForSearch(String query, String tag, String sort) {
         String[] queryList = null;
-        if(query!=null){
+        if (query != null) {
             queryList = query.split(" ");
         }
-        return imageRepository.findAllForSearch(sort,queryList,tag)
+        return imageRepository.findAllForSearch(sort, queryList, tag)
                 .stream()
                 .map(MainImageResponse::fromEntity)
                 .collect(Collectors.toList());
     }
 
-    public List<MainVideoResponse> getVideoForSearch(String q, String tag, String nickname, String sort){
-        List<MainVideoResponse> responses = videoService.getAllVideoForSearch(q,tag,nickname,sort)
+    public List<MainVideoResponse> getVideoForSearch(String q, String tag, String sort) {
+        List<MainVideoResponse> responses = videoService.getAllVideoForSearch(q, tag, sort)
                 .stream()
                 .map(MainVideoResponse::fromAllResponse)
                 .collect(Collectors.toList());
 
-        responses
-                .forEach(r->r.updateTags(videoService.getHashtagsStringByVideoId(r.getId())));
-
+        responses.forEach(video -> video.updateTags(
+                videoService.getHashtagKeywordStringInVideo(videoService.findVideoEntityById(video.getId()))));
         return responses;
     }
 
-    public List<AllPlaylistsResponse> getPlaylistsForSearch(String sort, String q, String nickname){
-        return playlistService.getAllPlaylistForSearch(q,sort,nickname);
+    public List<AllPlaylistsResponse> getPlaylistsForSearch(String sort, String q, String tag) {
+        return playlistService.getAllPlaylistForSearch(q, sort, tag);
     }
 
 }

--- a/src/main/java/com/example/backend/user/domain/User.java
+++ b/src/main/java/com/example/backend/user/domain/User.java
@@ -10,7 +10,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.springframework.web.multipart.MultipartFile;
 
 @Entity
 @Getter @Setter
@@ -92,6 +91,13 @@ public class User implements UserDetails{
 
     public void updateUserReportCount() {
         this.userReportCount += 1;
+    }
+
+    public static User createAnonymousUser() {
+        User user = new User();
+        user.setUserId(0L);
+        user.setNickname("anonymousUser");
+        return user;
     }
 
     public void updateUserProfileInfo(String nickname, String description, String imageUrl) {

--- a/src/main/java/com/example/backend/video/VideoController.java
+++ b/src/main/java/com/example/backend/video/VideoController.java
@@ -156,8 +156,12 @@ public class VideoController {
     }
 
     private User findUserByAuthentication() {
-        UserDetails principal = (UserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        return userService.findUserById(Long.parseLong(principal.getUsername()));
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        if (principal.equals("anonymousUser")) {
+            return User.createAnonymousUser();
+        }
+        UserDetails user = (UserDetails) principal;
+        return userService.findUserById(Long.parseLong(user.getUsername()));
     }
 
     private User findUserAndCheckAuthority(Long userId) {

--- a/src/main/java/com/example/backend/video/repository/CustomVideoRepository.java
+++ b/src/main/java/com/example/backend/video/repository/CustomVideoRepository.java
@@ -2,7 +2,6 @@ package com.example.backend.video.repository;
 
 import com.example.backend.video.domain.Video;
 import com.example.backend.video.dto.TempVideoDto;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
@@ -11,5 +10,5 @@ public interface CustomVideoRepository {
     TempVideoDto findAll(Pageable pageable, List<String> tags, String nickname, List<String> queries);
     List<Video> findBestVideos();
     List<Video> findTitleLike(String searchTitle, String order);
-    List<Video> findAllForSearch(List<String> tags, String nickname, List<String> queries, String sort);
+    List<Video> findAllForSearch(List<String> tags, List<String> queries, String sort);
 }

--- a/src/main/java/com/example/backend/video/repository/CustomVideoRepositoryImpl.java
+++ b/src/main/java/com/example/backend/video/repository/CustomVideoRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.example.backend.video.repository;
 
+import com.amazonaws.util.StringUtils;
 import com.example.backend.video.domain.Video;
 import com.example.backend.video.dto.TempVideoDto;
 import com.querydsl.core.types.Order;
@@ -18,6 +19,7 @@ import static com.example.backend.video.domain.QVideo.video;
 @RequiredArgsConstructor
 public class CustomVideoRepositoryImpl implements CustomVideoRepository{
     private final JPAQueryFactory jpaQueryFactory;
+    private final String EMPTY = "";
 
     @Override
     public List<Video> findBestVideos() {
@@ -80,22 +82,31 @@ public class CustomVideoRepositoryImpl implements CustomVideoRepository{
     }
 
     private BooleanExpression predicate(List<String> tags, List<String> queries){
-        return Expressions.anyOf(checkTag(tags), checkQuery(queries));
+        return Expressions.allOf(checkTag(tags), checkQuery(queries));
     }
 
     private BooleanExpression checkQuery(List<String> queryList){
+        if (queryList.isEmpty()) {
+            return null;
+        }
         return Expressions.anyOf(queryList.stream()
                 .map(video.description::contains)
                 .toArray(BooleanExpression[]::new));
     }
 
     private BooleanExpression checkTag(List<String> tags){
+        if (tags.isEmpty()) {
+            return null;
+        }
         return Expressions.anyOf(tags.stream()
                 .map(this::isTagInVideo)
                 .toArray(BooleanExpression[]::new));
     }
 
     private BooleanExpression isTagInVideo(String tag) {
+        if (StringUtils.isNullOrEmpty(tag)) {
+            return null;
+        }
         return video.videoHashtags.any().hashtag.hashtagName.eq(tag)
                 .or(video.customHashtags.any().customHashtagName.eq(tag));
     }

--- a/src/main/java/com/example/backend/video/repository/CustomVideoRepositoryImpl.java
+++ b/src/main/java/com/example/backend/video/repository/CustomVideoRepositoryImpl.java
@@ -1,30 +1,18 @@
 package com.example.backend.video.repository;
 
-import com.example.backend.customHashtag.CustomHashtag;
-import com.example.backend.customHashtag.QCustomHashtag;
-import com.example.backend.video.domain.QVideoHashtag;
 import com.example.backend.video.domain.Video;
-import com.example.backend.video.domain.VideoHashtag;
 import com.example.backend.video.dto.TempVideoDto;
-import com.querydsl.core.QueryResults;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
-import com.querydsl.core.types.dsl.ListPath;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
-import static com.example.backend.community.domain.QCommunityBoard.communityBoard;
-import static com.example.backend.image.domain.QImageBoard.imageBoard;
 import static com.example.backend.video.domain.QVideo.video;
 
 @RequiredArgsConstructor
@@ -53,7 +41,7 @@ public class CustomVideoRepositoryImpl implements CustomVideoRepository{
     }
 
     @Override
-    public List<Video> findAllForSearch(List<String> tags, String nickname, List<String> queries, String sort) {
+    public List<Video> findAllForSearch(List<String> tags, List<String> queries, String sort) {
         List<OrderSpecifier> orders=new ArrayList<>();
         if(sort.contains("like")){
             orders.add(new OrderSpecifier(Order.DESC, video.likeCount));
@@ -61,7 +49,7 @@ public class CustomVideoRepositoryImpl implements CustomVideoRepository{
         orders.add(new OrderSpecifier(Order.DESC, video.id));
 
         return jpaQueryFactory.selectFrom(video)
-                    .where(video.status.eq(true), predicate(tags, nickname, queries))
+                    .where(video.status.eq(true), predicate(tags, queries))
                     .orderBy(orders.toArray(OrderSpecifier[]::new))
                     .limit(8)
                     .fetch();
@@ -70,14 +58,14 @@ public class CustomVideoRepositoryImpl implements CustomVideoRepository{
 
     @Override
     public TempVideoDto findAll(Pageable pageable, List<String> tags, String nickname, List<String> queries) {
-        long pageOffset= pageable.getOffset()-4;
+        long pageOffset= pageable.getOffset() - 4; // 첫 페이지는 4개, 그 이후부터는 8개 조회
         int pageSize = pageable.getPageSize();
-        if(pageable.getPageNumber()==0){
+        if(pageable.getPageNumber() == 0){
             pageOffset=0;
             pageSize=4;
         }
         List<Video> videos = jpaQueryFactory.selectFrom(video)
-                .where(video.status.eq(true), predicate(tags, nickname, queries))
+                .where(video.status.eq(true), predicate(tags, queries))
                 .orderBy(order(pageable.getSort()).toArray(OrderSpecifier[]::new))
                 .offset(pageOffset)
                 .limit(pageSize)
@@ -85,63 +73,43 @@ public class CustomVideoRepositoryImpl implements CustomVideoRepository{
 
         Long totalCount = jpaQueryFactory.select(video.count())
                 .from(video)
-                .where(video.status.eq(true), predicate(tags, nickname, queries))
+                .where(video.status.eq(true), predicate(tags, queries))
                 .fetchOne();
 
         return new TempVideoDto(totalCount,videos);
     }
 
-    private BooleanExpression predicate(List<String> tags, String nickname, List<String> queries){
-        //해시태그에 있거나 키워드 (커스텀 해시태그) 에 있거나
-        BooleanExpression tagExpression=null;
-        BooleanExpression nicknameExpression=null;
-        BooleanExpression queryExpressions=null;
-        if(tags!=null){
-            tagExpression = Expressions.anyOf(tags.stream()
-                    .map(this::checkTag)
-                    .toArray(BooleanExpression[]::new));
-        }
-        if(nickname!=null){
-            nicknameExpression = checkNickname(nickname);
-        }
-
-        if(queries!=null){
-            queryExpressions=checkQuery(queries);
-        }
-
-        return Expressions.allOf(tagExpression,nicknameExpression,queryExpressions);
+    private BooleanExpression predicate(List<String> tags, List<String> queries){
+        return Expressions.anyOf(checkTag(tags), checkQuery(queries));
     }
 
     private BooleanExpression checkQuery(List<String> queryList){
-        if(queryList==null)
-            return null;
-        return Expressions.anyOf(queryList.stream().map(video.description::contains).toArray(BooleanExpression[]::new));
-
+        return Expressions.anyOf(queryList.stream()
+                .map(video.description::contains)
+                .toArray(BooleanExpression[]::new));
     }
 
-    //join 쿼리로 바꿀 수 있나?
-    private BooleanExpression checkTag(String tag){
-        ListPath<VideoHashtag, QVideoHashtag> videoHashtags = video.videoHashtags; //이 비디오의 VideoHashtags 매핑 데이터들
-        ListPath<CustomHashtag, QCustomHashtag> customHashtags = video.customHashtags;
-        return videoHashtags.any().hashtag.hashtagName.eq(tag).or(customHashtags.any().customHashtagName.eq(tag)); //하나라도 현재 검색하는 hashtag 와 겹치는게 있는가?
+    private BooleanExpression checkTag(List<String> tags){
+        return Expressions.anyOf(tags.stream()
+                .map(this::isTagInVideo)
+                .toArray(BooleanExpression[]::new));
     }
 
-    private BooleanExpression checkNickname(String nickname){
-        return video.user.nickname.eq(nickname);
+    private BooleanExpression isTagInVideo(String tag) {
+        return video.videoHashtags.any().hashtag.hashtagName.eq(tag)
+                .or(video.customHashtags.any().customHashtagName.eq(tag));
     }
-
 
     private List<OrderSpecifier> order(Sort sort){
         List<OrderSpecifier> orders=new ArrayList<>();
-        Order direction= Order.DESC;
         for(Sort.Order order : sort){
             String orderProperty = order.getProperty();
             switch (orderProperty){
                 case "id":
-                    orders.add(new OrderSpecifier(direction,video.id));
+                    orders.add(new OrderSpecifier(Order.DESC, video.id));
                     return orders;
                 case "likeCount":
-                    orders.add(new OrderSpecifier(direction,video.likeCount));
+                    orders.add(new OrderSpecifier(Order.DESC, video.likeCount));
                     break;
             }
         }

--- a/src/main/java/com/example/backend/video/service/VideoService.java
+++ b/src/main/java/com/example/backend/video/service/VideoService.java
@@ -154,19 +154,12 @@ public class VideoService {
         throw new NoSuchVideoException();
     }
 
-    private List<String> getHashtagKeywordStringInVideo(Video video) {
+    public List<String> getHashtagKeywordStringInVideo(Video video) {
         List<VideoHashtag> videoHashtags = video.getVideoHashtags();
         List<CustomHashtag> customHashtags = video.getCustomHashtags();
-        //두 개의 list 를 각각 string stream 으로 변경한 후, 두 stream을 하나로 합친 list를 반환
         return Stream.concat(videoHashtags.stream().map(videoHashtag -> videoHashtag.getHashtag().getHashtagName())
                         , customHashtags.stream().map(CustomHashtag::getCustomHashtagName))
                 .collect(Collectors.toList());
-    }
-
-    public List<String> getHashtagsStringByVideoId(Long videoId) {
-        Video video = this.findVideoEntityById(videoId);
-        List<VideoHashtag> videoHashtags = video.getVideoHashtags();
-        return videoHashtags.stream().map(v -> v.getHashtag().getHashtagName()).collect(Collectors.toList());
     }
 
     public DetailVideoResponse getDetailVideoResponse(Video video, Long loginId) {
@@ -202,20 +195,13 @@ public class VideoService {
         return new AllVideoResponseWithPageCount(allVideoResponses, getTotalPageCount(tempDto.getTotalCount()));
     }
 
-    public List<AllVideoResponse> getAllVideoForSearch(String q, String tag, String nickname, String sort) {
-        List<String> tags = null;
-        if (tag != null) {
-            tags = Arrays.stream(tag.split(",")).collect(Collectors.toList());
-        }
-        List<String> queries = null;
-        if (q != null) {
-            queries = Arrays.stream(q.split(" ")).collect(Collectors.toList());
-        }
-        return toAllResponse(videoRepository.findAllForSearch(tags, nickname, queries, sort));
+    public List<AllVideoResponse> getAllVideoForSearch(String q, String tag, String sort) {
+        List<String> tags = Arrays.stream(tag.split(",")).collect(Collectors.toList());
+        List<String> queries = Arrays.stream(q.split(" ")).collect(Collectors.toList());
+        return toAllResponse(videoRepository.findAllForSearch(tags, queries, sort));
     }
 
     private int getTotalPageCount(long pages) {
-        System.out.println("total elements = " + pages);
         if (pages <= 4) {
             return 1;
         }


### PR DESCRIPTION
제목
---
상제 조회 시, 로그인 되어 있지 않은 사용자의 접근 허용

작업내용
---
- [ ] 기능 추가
- [X] 기능 수정
- [ ] 버그 수정
- [ ] 기타 설정

수정내용
---
1. 상세 영상, 상세 플레이리스트 조회 시, 토큰이 없는 사용자인 경우에도 **익명의 사용자** 로 조회가 가능하도록 한다.
2. 익명의 사용자는 `userId` 를 데이터베이스에 존재하지 않는 값인 `0` 으로 설정하여 작성자 여부 및 좋아요 여부 판별 시 활용한다.
3. PR 날리고 알았는데 검색 기능도 같이 수정했습니다.. 허허 해시태그 기반 조회, 검색어 기반 조회 기능 구현 / 잡담, 짤 게시판은 사용하지 않는 걸로

주의사항
---
- 추후 `SecurityConfig` 에서 토큰이 있어야만 접근할 수 있는 API 와 토큰이 없어도 접근할 수 있는 API 를 설정해줄 때 
전체 조회  등 아예 토큰이 필요 없는 API와 함께  **상세 조회 API** 또한 `permitAll()` 로 설정하여 **로그인 되어 있지 않은 사용자도 접근할 수 있도록** 설정해주어야 할 것 같습니다! 
그리고 그 외의 반드시 토큰이 필요한 것 (ex. 사용자 정보 조회, 채팅, 글 작성) 등은 `authenticated()` 로 두어서 애초에 토큰이 없다면 (즉 로그인 되어있지 않다면) 아예 필터 단계 조차 넘기지 못하게 설정하면 되지 않을까 싶습니다
- 고쳐야 할 것 같은 점이나 문제가 생길 것 같은 부분이 있으면 리뷰 남겨주세요~!

- 검색 기능에서 해시태그 기반 검색의 경우, 와이어프레임을 보면 `#검색어` 와 같은 형태로 구성되는 것 같아서 1개의 해시태그를 기반으로 정확히 일치하는 태그를 가진 것만 검색된다고 생각하고 구현했습니다
