### PR TITLE
카카오톡 소셜로그인 수정

### DIFF
--- a/src/main/java/com/example/backend/oauth/OAuthController.java
+++ b/src/main/java/com/example/backend/oauth/OAuthController.java
@@ -45,6 +45,15 @@ public class OAuthController {
 
         if(user == null){
             User newUser = new User();
+            JsonNode tempEmail = userInfo.get("kakao_account").get("email");
+            if(tempEmail == null || tempEmail.isNull()){
+                newUser.setEmail(null);
+            }
+            else{
+                String email = tempEmail.toString();
+                email = email.substring(1, email.length()-1);
+                newUser.setEmail(email);
+            }
             newUser.setKakaoId(kakaoId);
             newUser.setProfileUrl(profileUrl);
             newUser.setNickname(nickname);

--- a/src/main/java/com/example/backend/user/domain/User.java
+++ b/src/main/java/com/example/backend/user/domain/User.java
@@ -40,6 +40,9 @@ public class User implements UserDetails{
     private String profileUrl;
 
     @Column(nullable = true)
+    private String email;
+
+    @Column(nullable = true)
     private String userDescription;
 
     @Column(nullable = false)

--- a/src/main/java/com/example/backend/user/repository/UserRepository.java
+++ b/src/main/java/com/example/backend/user/repository/UserRepository.java
@@ -8,5 +8,5 @@ import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
-    Optional<User> findByKakaoId(Long kakaoId);
+    Optional<User> findByKakaoIdAndStatus(Long kakaoId, Boolean status);
 }

--- a/src/main/java/com/example/backend/user/service/UserService.java
+++ b/src/main/java/com/example/backend/user/service/UserService.java
@@ -30,7 +30,7 @@ public class UserService implements UserDetailsService {
     }
 
     public User findUserByKakaoId(Long kakaoId){
-        Optional<User> user = userRepository.findByKakaoId(kakaoId);
+        Optional<User> user = userRepository.findByKakaoIdAndStatus(kakaoId,true);
         return user.orElse(null);
     }
 


### PR DESCRIPTION
제목
---
카카오톡 소셜로그인 수정

작업내용
---
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 버그 수정
- [ ] 기타 설정

수정내용
---
1. 사용자 탈퇴 후에 소셜로그인을 진행하면 새로운 계정이 만들어지도록 수정
2. 사용자가 카카오톡 소셜로그인 할 때, 이메일 수집 거부를 클릭하면 유저 이메일 정보에 null 값 들어가도록 수정

주의사항
---
- 테스트 과정에서 이메일 수집 거부를 선택하려 했는데 동의 항목이 아무리 시도해도 안뜨고 무조건 이메일 수집 동의로 설정되어서 테스트는 못해봤어유,,, 서버 올라가면 효원이한테 바로 테스트 부탁해볼게 ㅠ
